### PR TITLE
FISH-6280 Update for EE10

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,4 @@ latest-*.zip
 .settings/
 target
 .idea/
-
+*.iml

--- a/build.xml
+++ b/build.xml
@@ -68,7 +68,7 @@
 
     <target name="run.all.tests" depends="sigtest, test"/>
 
-    <target name="test" depends="config.v4, filter.arquillian.xml">
+    <target name="test" depends="config.v4, filter.arquillian.xml, determine.mvn.profiles">
 
         <antcall target="start.javadb"/>
         <delete file="${porting.home}/glassfish-tck-runner/pom.xml"/>
@@ -444,7 +444,7 @@
         <stop.domain/>
     </target>
 
-    <presetdef name="determine.mvn.profiles">
+    <target name="determine.mvn.profiles">
         <if>
             <equals arg1="${javaee.level}" arg2="core" trim="true"/>
             <then>
@@ -463,10 +463,9 @@
                 <property name="profiles" value="payara-managed,platform"/>
             </else>
         </if>
-    </presetdef>
+    </target>
 
     <presetdef name="mvn.test">
-        <determine.mvn.profiles/>
         <exec executable="${maven.executable}">
             <arg value="--global-settings"/>
             <arg value="${porting.home}/settings.xml"/>
@@ -479,7 +478,6 @@
     </presetdef>
 
     <presetdef name="mvn.dependency-tree">
-        <determine.mvn.profiles/>
         <exec executable="${maven.executable}">
             <arg value="--global-settings"/>
             <arg value="${porting.home}/settings.xml"/>
@@ -490,7 +488,6 @@
     </presetdef>
 
     <presetdef name="mvn.test.win">
-        <determine.mvn.profiles/>
         <exec executable="cmd">
             <arg value="/c"/>
             <arg value="${maven.executable}.cmd"/>
@@ -504,7 +501,6 @@
     </presetdef>
 
     <presetdef name="mvn.dependency-tree.win">
-        <determine.mvn.profiles/>
         <exec executable="cmd">
             <arg value="/c"/>
             <arg value="${maven.executable}.cmd"/>

--- a/build.xml
+++ b/build.xml
@@ -51,12 +51,6 @@
         </or>
     </condition>
 
-    <condition property="excluded.groups" value="&lt;excludedGroups&gt;javaee-full,se&lt;/excludedGroups&gt;"
-               else="&lt;excludedGroups&gt;se&lt;/excludedGroups&gt;">
-        <equals arg1="${javaee.level}" arg2="web" trim="true"/>
-    </condition>
-
-
     <condition property="aix.jars" value="${pathsep}${java.home}/lib/annotation.jar${pathsep}${java.home}/lib/vm.jar"
                else="">
         <and>
@@ -92,6 +86,7 @@
             </or>
             <then>
                 <mvn.test.win dir="glassfish-tck-runner"/>
+                <mvn.dependency-tree.win dir="glassfish-tck-runner"/>
             </then>
             <else>
                 <echo message="################# Dependencies at: ${env.DIST}/${env.CDI_TCK_DIST}/artifacts/cdi-tck-impl-${env.CDI_TCK_VERSION}.jar #################"/>
@@ -449,40 +444,74 @@
         <stop.domain/>
     </target>
 
+    <presetdef name="determine.mvn.profiles">
+        <if>
+            <equals arg1="${javaee.level}" arg2="core" trim="true"/>
+            <then>
+                <echo message="Testing Core Profile"/>
+                <property name="profiles" value="payara-managed,core"/>
+            </then>
+            <elseif>
+                <equals arg1="${javaee.level}" arg2="web" trim="true"/>
+                <then>
+                    <echo message="Testing Web Profile"/>
+                    <property name="profiles" value="payara-managed,web"/>
+                </then>
+            </elseif>
+            <else>
+                <echo message="Testing Platform (Full Profile)"/>
+                <property name="profiles" value="payara-managed,platform"/>
+            </else>
+        </if>
+    </presetdef>
 
     <presetdef name="mvn.test">
+        <determine.mvn.profiles/>
         <exec executable="${maven.executable}">
             <arg value="--global-settings"/>
             <arg value="${porting.home}/settings.xml"/>
             <arg value="-P"/>
-            <arg value="payara-managed"/>
+            <arg value="${profiles}"/>
             <arg value="-U"/>
             <arg value="clean"/>
             <arg value="test"/>
-            <arg value="dependency:tree"/>
         </exec>
     </presetdef>
 
     <presetdef name="mvn.dependency-tree">
+        <determine.mvn.profiles/>
         <exec executable="${maven.executable}">
             <arg value="--global-settings"/>
             <arg value="${porting.home}/settings.xml"/>
             <arg value="-P"/>
-            <arg value="payara-managed"/>
+            <arg value="${profiles}"/>
             <arg value="dependency:tree"/>
         </exec>
     </presetdef>
 
     <presetdef name="mvn.test.win">
+        <determine.mvn.profiles/>
         <exec executable="cmd">
             <arg value="/c"/>
             <arg value="${maven.executable}.cmd"/>
             <arg value="--global-settings"/>
             <arg value="${porting.home}/settings.xml"/>
             <arg value="-P"/>
-            <arg value="payara-managed"/>
+            <arg value="${profiles}"/>
             <arg value="-U"/>
             <arg value="test"/>
+        </exec>
+    </presetdef>
+
+    <presetdef name="mvn.dependency-tree.win">
+        <determine.mvn.profiles/>
+        <exec executable="cmd">
+            <arg value="/c"/>
+            <arg value="${maven.executable}.cmd"/>
+            <arg value="--global-settings"/>
+            <arg value="${porting.home}/settings.xml"/>
+            <arg value="-P"/>
+            <arg value="${profiles}"/>
             <arg value="dependency:tree"/>
         </exec>
     </presetdef>

--- a/build.xml
+++ b/build.xml
@@ -43,14 +43,6 @@
 
     <taskdef resource="net/sf/antcontrib/antlib.xml" classpath="${lib}/ant-contrib.jar"/>
 
-    <condition property="max.classes.restart" value="10"
-               else="40">
-        <or>
-            <os family="windows"/>
-            <os family="dos"/>
-        </or>
-    </condition>
-
     <condition property="aix.jars" value="${pathsep}${java.home}/lib/annotation.jar${pathsep}${java.home}/lib/vm.jar"
                else="">
         <and>
@@ -143,7 +135,6 @@
         <copy file="${porting.home}/glassfish-tck-runner/src/test/glassfish-managed/arquillian.template.xml"
               tofile="${porting.home}/glassfish-tck-runner/src/test/glassfish-managed/arquillian.xml">
             <filterset>
-                <filter token="maxClassesRestart" value="${max.classes.restart}"/>
                 <filter token="payaraHome" value="${glassfish.home.base}"/>
                 <filter token="adminHost" value="${admin.host}"/>
                 <filter token="adminPort" value="${admin.port}"/>

--- a/build.xml
+++ b/build.xml
@@ -20,118 +20,117 @@
 
 <project name="CDI TCK Glassfish Porting" default="dist" basedir=".">
 
-    <property environment="env" />
-    <property file="${basedir}/build.properties" />
+    <property environment="env"/>
+    <property file="${basedir}/build.properties"/>
 
-	<property name="maven.executable" value="${env.M2_HOME}/bin/mvn" />
-	<property name="pathsep" value="${path.separator}"/>
-	<property name="portingkit.version" value="3.0.2"/>
-	<property name="src" value="${basedir}/src" />
-	<property name="classes" value="${basedir}/classes" />
-	<property name="dist" value="${basedir}/dist" />
-	<property name="lib" value="${basedir}/lib" />
-	<property name="dist.file" value="cdi-tck-payara-porting" />
-	<property name="admin.port" value="4848"/>
-	<property name="admin.host" value="localhost"/>
-	<property name="javadb.home" value="${glassfish.home}/../javadb"/>
-        <property name="javadb.host" value="localhost"/>
-        <property name="javadb.port" value="1527"/>
-        <!-- number of seconds to wait for the v4 admin port to be available -->
-    <property name="wait.for.v4" value="90"/> 
-    <property name="sig.file" value="${porting.home}/cdi-tck-impl-sigtest.sig" />
+    <property name="maven.executable" value="${env.M2_HOME}/bin/mvn"/>
+    <property name="pathsep" value="${path.separator}"/>
+    <property name="portingkit.version" value="3.0.2"/>
+    <property name="src" value="${basedir}/src"/>
+    <property name="classes" value="${basedir}/classes"/>
+    <property name="dist" value="${basedir}/dist"/>
+    <property name="lib" value="${basedir}/lib"/>
+    <property name="dist.file" value="cdi-tck-payara-porting"/>
+    <property name="admin.port" value="4848"/>
+    <property name="admin.host" value="localhost"/>
+    <property name="javadb.home" value="${glassfish.home}/../javadb"/>
+    <property name="javadb.host" value="localhost"/>
+    <property name="javadb.port" value="1527"/>
+    <!-- number of seconds to wait for the v4 admin port to be available -->
+    <property name="wait.for.v4" value="90"/>
+    <property name="sig.file" value="${porting.home}/cdi-tck-impl-sigtest.sig"/>
 
-        
-        <taskdef resource="net/sf/antcontrib/antlib.xml" classpath="${lib}/ant-contrib.jar" />
 
-        <condition property="max.classes.restart" value="10"
-                                   else="40">    
+    <taskdef resource="net/sf/antcontrib/antlib.xml" classpath="${lib}/ant-contrib.jar"/>
+
+    <condition property="max.classes.restart" value="10"
+               else="40">
+        <or>
+            <os family="windows"/>
+            <os family="dos"/>
+        </or>
+    </condition>
+
+    <condition property="excluded.groups" value="&lt;excludedGroups&gt;javaee-full,se&lt;/excludedGroups&gt;"
+               else="&lt;excludedGroups&gt;se&lt;/excludedGroups&gt;">
+        <equals arg1="${javaee.level}" arg2="web" trim="true"/>
+    </condition>
+
+
+    <condition property="aix.jars" value="${pathsep}${java.home}/lib/annotation.jar${pathsep}${java.home}/lib/vm.jar"
+               else="">
+        <and>
+            <available file="${java.home}/lib/annotation.jar"/>
+            <available file="${java.home}/lib/vm.jar"/>
+        </and>
+    </condition>
+
+    <!--Get Glassfish install dir base (minus the glassfish dir) -->
+    <propertyregex property="glassfish.home.base"
+                   input="${glassfish.home}"
+                   regexp="(.*)[\/|\\]glassfish"
+                   select="\1"
+                   defaultValue="${glassfish.home}"/>
+
+    <target name="run.all.tests" depends="sigtest, test"/>
+
+    <target name="test" depends="config.v4, filter.arquillian.xml">
+
+        <antcall target="start.javadb"/>
+        <delete file="${porting.home}/glassfish-tck-runner/pom.xml"/>
+        <copy file="${porting.home}/glassfish-tck-runner/pom.template.xml"
+              tofile="${porting.home}/glassfish-tck-runner/pom.xml">
+            <filterset>
+                <filter token="excludedGroups" value="${excluded.groups}"/>
+            </filterset>
+        </copy>
+
+        <if>
             <or>
                 <os family="windows"/>
                 <os family="dos"/>
-            </or>     
-        </condition>
-        
-        <condition property="excluded.groups" value="&lt;excludedGroups&gt;javaee-full,se&lt;/excludedGroups&gt;"
-                                   else="&lt;excludedGroups&gt;se&lt;/excludedGroups&gt;">    
-            <equals arg1="${javaee.level}" arg2="web" trim="true"/>    
-        </condition>
-       
-        
+            </or>
+            <then>
+                <mvn.test.win dir="glassfish-tck-runner"/>
+            </then>
+            <else>
+                <echo message="################# Dependencies at: ${env.DIST}/${env.CDI_TCK_DIST}/artifacts/cdi-tck-impl-${env.CDI_TCK_VERSION}.jar #################"/>
+                <mvn.test dir="glassfish-tck-runner"/>
+                <mvn.dependency-tree dir="glassfish-tck-runner"/>
+            </else>
+        </if>
 
-        <condition property="aix.jars" value="${pathsep}${java.home}/lib/annotation.jar${pathsep}${java.home}/lib/vm.jar"
-                                       else="">
-            <and>
-                <available file="${java.home}/lib/annotation.jar"/>
-                <available file="${java.home}/lib/vm.jar"/>
-            </and>
-        </condition>
-        
-        <!--Get Glassfish install dir base (minus the glassfish dir) -->
-        <propertyregex property="glassfish.home.base"
-                       input="${glassfish.home}"
-                       regexp="(.*)[\/|\\]glassfish"
-                       select="\1"
-                       defaultValue="${glassfish.home}"/>
-        
-        <target name="run.all.tests" depends="sigtest, test"/>
-
-        <target name="test" depends="config.v4, filter.arquillian.xml">
-            
-            <antcall target="start.javadb" />
-            <delete file="${porting.home}/glassfish-tck-runner/pom.xml"/>
-            <copy file="${porting.home}/glassfish-tck-runner/pom.template.xml"
-                  tofile="${porting.home}/glassfish-tck-runner/pom.xml">
-                <filterset>                  
-                  <filter token="excludedGroups" value="${excluded.groups}"/>
-                </filterset>
-            </copy>
-            
-            <if>
-                <or>
-                 <os family="windows"/>
-                 <os family="dos"/>
-                </or>
-                <then>
-                    <mvn.test.win dir="glassfish-tck-runner"/>
-                </then>
-                <else>
-                    <echo message="################# Dependencies at: ${env.DIST}/${env.CDI_TCK_DIST}/artifacts/cdi-tck-impl-${env.CDI_TCK_VERSION}.jar #################"/>
-                    <mvn.test dir="glassfish-tck-runner"/>
-                    <mvn.dependency-tree dir="glassfish-tck-runner"/>
-                </else>
-            </if>
-            
-            <antcall target="stop.javadb" />     
+        <antcall target="stop.javadb"/>
     </target>
 
     <target name="sigtest">
         <echo message="Java Specification Version in use:  ${java.specification.version}"/>
-                <echo message="Java Home:  ${java.home}"/>
-                   
-                <java outputproperty="sigoutput" fork="true" jar="${lib}/sigtest.jar">
+        <echo message="Java Home:  ${java.home}"/>
+
+        <java outputproperty="sigoutput" fork="true" jar="${lib}/sigtest.jar">
             <arg value="Signaturetest"/>
-                        <arg value="-Classpath"/>
-                        <arg value="${java.home}/${java.classes.for.sig.ext}${pathsep}${glassfish.home}/modules/weld-osgi-bundle.jar${pathsep}${glassfish.home}/modules/jakarta.enterprise.cdi-api.jar${pathsep}${glassfish.home}/modules/jakarta.inject-api.jar${pathsep}${glassfish.home}/modules/jakarta.el.jar/${pathsep}${glassfish.home}/modules/jakarta.interceptor-api.jar${aix.jars}${pathsep}${glassfish.home}/modules/cdi-api-fragment.jar"/>
-                        <arg value="-Package"/>
-                        <arg value="jakarta.enterprise"/>
-                        <arg value="-Package"/>
-                        <arg value="jakarta.decorator"/>
-                        <arg value="-FileName"/>
-                        <arg value="${sig.file}"/>
-                        <arg value="-Static"/>
+            <arg value="-Classpath"/>
+            <arg value="${java.home}/${java.classes.for.sig.ext}${pathsep}${glassfish.home}/modules/weld-osgi-bundle.jar${pathsep}${glassfish.home}/modules/jakarta.enterprise.cdi-api.jar${pathsep}${glassfish.home}/modules/jakarta.inject-api.jar${pathsep}${glassfish.home}/modules/jakarta.el.jar/${pathsep}${glassfish.home}/modules/jakarta.interceptor-api.jar${aix.jars}${pathsep}${glassfish.home}/modules/cdi-api-fragment.jar"/>
+            <arg value="-Package"/>
+            <arg value="jakarta.enterprise"/>
+            <arg value="-Package"/>
+            <arg value="jakarta.decorator"/>
+            <arg value="-FileName"/>
+            <arg value="${sig.file}"/>
+            <arg value="-Static"/>
         </java>
-                <mkdir dir="${report.dir}"/>
-                <echo message="${sigoutput}"/>
-                <echo message="${sigoutput}" file="${report.dir}/cdi_sig_test_results.txt"/>
-                <echo message="Output is also saved to ${report.dir}/cdi_sig_test_results.txt"/>
+        <mkdir dir="${report.dir}"/>
+        <echo message="${sigoutput}"/>
+        <echo message="${sigoutput}" file="${report.dir}/cdi_sig_test_results.txt"/>
+        <echo message="Output is also saved to ${report.dir}/cdi_sig_test_results.txt"/>
     </target>
 
     <target name="copy.settingsxml">
-    <!--
-            <copy file="${porting.home}/settings.xml" todir="${user.home}/.m2"
-                  flatten="true" overwrite="true">
-            </copy>
-    -->
+        <!--
+                <copy file="${porting.home}/settings.xml" todir="${user.home}/.m2"
+                      flatten="true" overwrite="true">
+                </copy>
+        -->
     </target>
     <target name="copy.tck.ext.lib.jar">
         <echo message="Copying cdi-ext-lib jar"/>
@@ -158,60 +157,61 @@
             </filterset>
         </copy>
     </target>
-        
+
     <target name="dist">
         <delete file="${dist}/${dist.file}-${portingkit.version}_${time.stamp.bundle.string}.zip"/>
         <delete file="${porting.home}/glassfish-tck-runner/pom.xml"/>
-        <delete file="${porting.home}/glassfish-tck-runner/src/test/glassfish-managed/arquillian.xml"/>                 
+        <delete file="${porting.home}/glassfish-tck-runner/src/test/glassfish-managed/arquillian.xml"/>
         <if>
-            <available file="${basedir}/build.properties.sani" />
+            <available file="${basedir}/build.properties.sani"/>
             <then>
-                    <property name="prop.file" value="build.properties.sani" />
+                <property name="prop.file" value="build.properties.sani"/>
             </then>
             <else>
-                    <property name="prop.file" value="build.properties" />
+                <property name="prop.file" value="build.properties"/>
             </else>
         </if>
 
         <tstamp>
-            <format property="time.stamp.bundle.string" pattern="dd-MMM-yyyy" locale="en" />
+            <format property="time.stamp.bundle.string" pattern="dd-MMM-yyyy" locale="en"/>
         </tstamp>
 
         <zip destfile="${dist}/${dist.file}-${portingkit.version}_${time.stamp.bundle.string}.zip">
             <zipfileset dir="${basedir}" includes="*.xml, build.properties, classes/**,
                             lib/*.jar, glassfish-tck-runner/**, readme.txt, *.sig, password.template"
-                            excludes="domain*.xml, lib/sigtestdev.jar, glassfish-tck-runner/target/**, glassfish-tck-runner/target*/**, glassfish-tck-runner/src/test/tck20/tck-tests_*" prefix="cdi-tck-glassfish-porting" />
-            <zipfileset dir="${basedir}" includes="${prop.file}" fullpath="cdi-tck-glassfish-porting/build.properties" />
+                        excludes="domain*.xml, lib/sigtestdev.jar, glassfish-tck-runner/target/**, glassfish-tck-runner/target*/**, glassfish-tck-runner/src/test/tck20/tck-tests_*"
+                        prefix="cdi-tck-glassfish-porting"/>
+            <zipfileset dir="${basedir}" includes="${prop.file}" fullpath="cdi-tck-glassfish-porting/build.properties"/>
         </zip>
 
-        <delete file="${basedir}/build.properties.sani" quiet="true" />
+        <delete file="${basedir}/build.properties.sani" quiet="true"/>
     </target>
 
     <target name="dist.sani">
-        <edit.prop.file />                  
-                <antcall target="dist" />
+        <edit.prop.file/>
+        <antcall target="dist"/>
     </target>
 
     <macrodef name="edit.prop.file">
         <sequential>
-            <loadfile srcfile="${basedir}/build.properties" property="props" />
+            <loadfile srcfile="${basedir}/build.properties" property="props"/>
 
             <propertyregex property="porting.home.prop"
-                 input="${props}"
-                 regexp="(porting.home=)(.*)"
-                 replace="\1"
-                 defaultvalue="${props}"
-                 override="true"/>
+                           input="${props}"
+                           regexp="(porting.home=)(.*)"
+                           replace="\1"
+                           defaultvalue="${props}"
+                           override="true"/>
 
             <propertyregex property="glassfish.home.prop"
-                 input="${porting.home.prop}"
-                 regexp="(glassfish.home=)(.*)"
-                 replace="\1"
-                 defaultvalue="${porting.home.prop}"
-                 override="true"/>
+                           input="${porting.home.prop}"
+                           regexp="(glassfish.home=)(.*)"
+                           replace="\1"
+                           defaultvalue="${porting.home.prop}"
+                           override="true"/>
 
             <echo message="${glassfish.home.prop}"
-                      file="${basedir}/build.properties.sani"/>
+                  file="${basedir}/build.properties.sani"/>
 
         </sequential>
     </macrodef>
@@ -227,23 +227,23 @@
     -->
     <presetdef name="stop.domain">
         <if>
-            <os family="unix" />
+            <os family="unix"/>
             <then>
                 <exec dir="${glassfish.home}/bin" executable="${glassfish.home}/bin/stopserv">
-                    <env key="PATH" path="${java.home}/bin${pathsep}${env.PATH}" />
+                    <env key="PATH" path="${java.home}/bin${pathsep}${env.PATH}"/>
                 </exec>
-                <sleep seconds="2" />
+                <sleep seconds="2"/>
             </then>
             <elseif>
                 <or>
-                    <os family="windows" />
-                    <os family="dos" />
+                    <os family="windows"/>
+                    <os family="dos"/>
                 </or>
                 <then>
                     <exec dir="${glassfish.home}/bin" executable="${glassfish.home}/bin/stopserv.bat">
-                        <env key="PATH" path="${java.home}/bin${pathsep}${env.PATH}" />
+                        <env key="PATH" path="${java.home}/bin${pathsep}${env.PATH}"/>
                     </exec>
-                    <sleep seconds="2" />
+                    <sleep seconds="2"/>
                 </then>
             </elseif>
             <else>
@@ -255,23 +255,23 @@
 
     <presetdef name="start.domain">
         <if>
-            <os family="unix" />
+            <os family="unix"/>
             <then>
                 <exec dir="${glassfish.home}/bin" executable="${glassfish.home}/bin/startserv" spawn="true">
-                    <env key="PATH" path="${java.home}/bin${pathsep}${env.PATH}" />
+                    <env key="PATH" path="${java.home}/bin${pathsep}${env.PATH}"/>
                 </exec>
-                <sleep seconds="2" />
+                <sleep seconds="2"/>
             </then>
             <elseif>
                 <or>
-                    <os family="windows" />
-                    <os family="dos" />
+                    <os family="windows"/>
+                    <os family="dos"/>
                 </or>
                 <then>
                     <exec dir="${glassfish.home}/bin" executable="${glassfish.home}/bin/startserv.bat" spawn="true">
-                        <env key="PATH" path="${java.home}/bin${pathsep}${env.PATH}" />
+                        <env key="PATH" path="${java.home}/bin${pathsep}${env.PATH}"/>
                     </exec>
-                    <sleep seconds="2" />
+                    <sleep seconds="2"/>
                 </then>
             </elseif>
             <else>
@@ -283,65 +283,65 @@
 
     <macrodef name="edit.domain.xml">
         <sequential>
-            <property name="domain.file" value="${glassfish.home}/domains/domain1/config/domain.xml" />
-            
-            <copy file="${domain.file}" tofile="${domain.file}.original" failonerror="false" />
-            
-                        
-                        <loadfile property="domain.file.contents" srcfile="${domain.file}" />
+            <property name="domain.file" value="${glassfish.home}/domains/domain1/config/domain.xml"/>
+
+            <copy file="${domain.file}" tofile="${domain.file}.original" failonerror="false"/>
+
+
+            <loadfile property="domain.file.contents" srcfile="${domain.file}"/>
             <propertyregex property="heap.found" input="${domain.file.contents}"
-                regexp="&lt;jvm-options>-Xmx(.*)&lt;/jvm-options>"
-                replace="&lt;jvm-options>-Xmx${max.heap.size}&lt;/jvm-options>"
-                defaultvalue="true" />
+                           regexp="&lt;jvm-options>-Xmx(.*)&lt;/jvm-options>"
+                           replace="&lt;jvm-options>-Xmx${max.heap.size}&lt;/jvm-options>"
+                           defaultvalue="true"/>
             <if>
-                <istrue value="${heap.found}" />
+                <istrue value="${heap.found}"/>
                 <then>
                     <echo>Max heap VM option not found in java-config.</echo>
                 </then>
                 <else>
                     <echo>Setting max heap value to ${max.heap.size}</echo>
-                    <echo message="${heap.found}" file="${domain.file}" />
+                    <echo message="${heap.found}" file="${domain.file}"/>
                     <echo>${domain.file} written to disk.</echo>
                 </else>
             </if>
 
-            <loadfile property="domain.file.contents2" srcfile="${domain.file}" />
+            <loadfile property="domain.file.contents2" srcfile="${domain.file}"/>
             <propertyregex property="perm.gen.found" input="${domain.file.contents2}"
-                regexp="&lt;jvm-options>-XX:MaxPermSize=(.*)&lt;/jvm-options>"
-                replace="&lt;jvm-options>-XX:MaxPermSize=${max.perm.gen.size}&lt;/jvm-options>"
-                defaultvalue="true" />
+                           regexp="&lt;jvm-options>-XX:MaxPermSize=(.*)&lt;/jvm-options>"
+                           replace="&lt;jvm-options>-XX:MaxPermSize=${max.perm.gen.size}&lt;/jvm-options>"
+                           defaultvalue="true"/>
             <if>
-                <istrue value="${perm.gen.found}" />
+                <istrue value="${perm.gen.found}"/>
                 <then>
                     <echo>Max permgen VM option not found in java-config.</echo>
                 </then>
                 <else>
                     <echo>Setting max permgen value to ${max.perm.gen.size}</echo>
-                    <echo message="${perm.gen.found}" file="${domain.file}" />
+                    <echo message="${perm.gen.found}" file="${domain.file}"/>
                     <echo>${domain.file} written to disk.</echo>
                 </else>
             </if>
 
-            <loadfile property="domain.file.contents3" srcfile="${domain.file}" />
+            <loadfile property="domain.file.contents3" srcfile="${domain.file}"/>
             <propertyregex property="ea.set" input="${domain.file.contents3}"
-                regexp="&lt;jvm-options>-ea&lt;/jvm-options>"
-                select="true"
-                defaultvalue="false" />
+                           regexp="&lt;jvm-options>-ea&lt;/jvm-options>"
+                           select="true"
+                           defaultvalue="false"/>
             <if>
-                <isfalse value="${ea.set}" />
+                <isfalse value="${ea.set}"/>
                 <then>
                     <propertyregex property="java.config" input="${domain.file.contents3}"
-                        regexp="(&lt;/java-config>)"
-                        replace="&lt;jvm-options>-ea:org.jboss.cdi.tck...&lt;/jvm-options>\1"
-                        defaultvalue="true" />
+                                   regexp="(&lt;/java-config>)"
+                                   replace="&lt;jvm-options>-ea:org.jboss.cdi.tck...&lt;/jvm-options>\1"
+                                   defaultvalue="true"/>
                     <if>
-                        <istrue value="${java.config}" />
+                        <istrue value="${java.config}"/>
                         <then>
                             <echo>java-config NOT found, something bad happened.</echo>
                         </then>
                         <else>
                             <echo>Adding -ea VM option to java-config.</echo>
-                            <echo message="${java.config}" file="${domain.file}" />
+                            <echo message="${java.config}" file="${domain.file}"/>
                             <echo>${domain.file} written to disk.</echo>
                         </else>
                     </if>
@@ -350,100 +350,103 @@
                     <echo>-ea VM option already set in java-config, so not setting.</echo>
                 </else>
             </if>
-                        
+
             <if>
                 <or>
-                    <os family="windows" />
-                    <os family="dos" />
+                    <os family="windows"/>
+                    <os family="dos"/>
                 </or>
                 <then>
-                    <property name="serverpolicy.file" value="${glassfish.home}/domains/domain1/config/server.policy" />
-                                        <mkdir dir="c:\\tmp" />
-                                        <mkdir dir="c:\\t" />
-                                        <replace file="${domain.file}" value="c:\\t">
-                                          <replacetoken>${com.sun.aas.instanceRoot}/applications</replacetoken>
-                                        </replace>
-                                        <replace file="${serverpolicy.file}" value="c:\\t">
-                                          <replacetoken>${com.sun.aas.instanceRoot}/applications</replacetoken>
-                                        </replace>
+                    <property name="serverpolicy.file" value="${glassfish.home}/domains/domain1/config/server.policy"/>
+                    <mkdir dir="c:\\tmp"/>
+                    <mkdir dir="c:\\t"/>
+                    <replace file="${domain.file}" value="c:\\t">
+                        <replacetoken>${com.sun.aas.instanceRoot}/applications</replacetoken>
+                    </replace>
+                    <replace file="${serverpolicy.file}" value="c:\\t">
+                        <replacetoken>${com.sun.aas.instanceRoot}/applications</replacetoken>
+                    </replace>
                 </then>
             </if>
         </sequential>
     </macrodef>
 
     <target name="stop.v4.domain">
-        <stop.domain />
+        <stop.domain/>
     </target>
-    
+
     <target name="restart.v4.domain">
-            <echo message="Restarting the Glassfish domain"/>
-            <stop.domain />
-            <start.domain />
-            <waitfor maxwait="${wait.for.v4}" maxwaitunit="second" checkevery="1" checkeveryunit="second">
-              <socket server="${admin.host}" port="${admin.port}"/>
-            </waitfor>
-            <echo>Domain started.</echo>
-    </target>
-
-        <target name="start.javadb">
-            <echo message="*** Starting JavaDB "/>
-            <java classname="org.apache.derby.drda.NetworkServerControl"
-                 classpath="${javadb.home}/lib/derby.jar${pathsep}${javadb.home}/lib/derbynet.jar${pathsep}${javadb.home}/lib/derbytools.jar${pathsep}${javadb.home}/lib/derbyclient.jar" fork="true" spawn="true">
-                <sysproperty key="derby.system.home" value="${javadb.home}/databases"/>
-                <sysproperty key="java.security.manager" value=""/>
-                <sysproperty key="java.security.policy" value="${glassfish.home}/domains/domain1/config/server.policy"/>
-                <arg line="-h ${javadb.host} -p ${javadb.port} start"/>
-            </java>
-            <sleep seconds="4"/>
-            <echo message="*** JavaDB Started "/>
-        </target>
-
-        <target name="stop.javadb">
-            <java classname="org.apache.derby.drda.NetworkServerControl"
-             classpath="${javadb.home}/lib/derby.jar${pathsep}${javadb.home}/lib/derbynet.jar${pathsep}${javadb.home}/lib/derbytools.jar${pathsep}${javadb.home}/lib/derbyclient.jar" fork="true" spawn="true">
-             <arg line="-h ${javadb.host} -p ${javadb.port} shutdown"/>
-            </java>
-            <echo message="*** JavaDB Stopped "/>
-        </target>
-
-        <target name="clean">
-            <delete dir="${porting.home}/glassfish-tck-runner/target" quiet="true" />
-            <echo message="*** Deleted ${porting.home}/glassfish-tck-runner/target"/>
-            <delete dir="${porting.home}/reports" quiet="true" />
-            <echo message="*** Deleted ${porting.home}/reports"/>
-        </target>
-        
-        <target name="config.v4">                       
-                <stop.domain />
-				<if>
-                <or>
-                 <os family="windows"/>
-                 <os family="dos"/>
-                </or>
-                <then>
-                    <mvn.dependency.win dir="glassfish-tck-runner"/>
-                </then>
-                <else>
-                    <mvn.dependency dir="glassfish-tck-runner"/>
-                </else>
-				</if>
-                <antcall target="copy.tck.ext.lib.jar"/>                
-        <antcall target="clean" />
-                <edit.domain.xml />
-        <start.domain />
-        <echo>Checking for a socket on ${admin.host} at port ${admin.port}, will wait up to ${wait.for.v4} seconds</echo>
+        <echo message="Restarting the Glassfish domain"/>
+        <stop.domain/>
+        <start.domain/>
         <waitfor maxwait="${wait.for.v4}" maxwaitunit="second" checkevery="1" checkeveryunit="second">
-          <socket server="${admin.host}" port="${admin.port}"/>
+            <socket server="${admin.host}" port="${admin.port}"/>
         </waitfor>
         <echo>Domain started.</echo>
-                <ant antfile="glassfish.xml" target="add.jvm.options"/>
-                <ant antfile="glassfish.xml" target="enable.jms"/>
-                <ant antfile="glassfish.xml" target="set.implicit.cdi"/>
-                <ant antfile="glassfish.xml" target="add.cdi.tck.users"/>
-                
-                <antcall target="stop.javadb" />
-                <antcall target="start.javadb" />
-                <stop.domain/>
+    </target>
+
+    <target name="start.javadb">
+        <echo message="*** Starting JavaDB "/>
+        <java classname="org.apache.derby.drda.NetworkServerControl"
+              classpath="${javadb.home}/lib/derby.jar${pathsep}${javadb.home}/lib/derbynet.jar${pathsep}${javadb.home}/lib/derbytools.jar${pathsep}${javadb.home}/lib/derbyclient.jar"
+              fork="true" spawn="true">
+            <sysproperty key="derby.system.home" value="${javadb.home}/databases"/>
+            <sysproperty key="java.security.manager" value=""/>
+            <sysproperty key="java.security.policy" value="${glassfish.home}/domains/domain1/config/server.policy"/>
+            <arg line="-h ${javadb.host} -p ${javadb.port} start"/>
+        </java>
+        <sleep seconds="4"/>
+        <echo message="*** JavaDB Started "/>
+    </target>
+
+    <target name="stop.javadb">
+        <java classname="org.apache.derby.drda.NetworkServerControl"
+              classpath="${javadb.home}/lib/derby.jar${pathsep}${javadb.home}/lib/derbynet.jar${pathsep}${javadb.home}/lib/derbytools.jar${pathsep}${javadb.home}/lib/derbyclient.jar"
+              fork="true" spawn="true">
+            <arg line="-h ${javadb.host} -p ${javadb.port} shutdown"/>
+        </java>
+        <echo message="*** JavaDB Stopped "/>
+    </target>
+
+    <target name="clean">
+        <delete dir="${porting.home}/glassfish-tck-runner/target" quiet="true"/>
+        <echo message="*** Deleted ${porting.home}/glassfish-tck-runner/target"/>
+        <delete dir="${porting.home}/reports" quiet="true"/>
+        <echo message="*** Deleted ${porting.home}/reports"/>
+    </target>
+
+    <target name="config.v4">
+        <stop.domain/>
+        <if>
+            <or>
+                <os family="windows"/>
+                <os family="dos"/>
+            </or>
+            <then>
+                <mvn.dependency.win dir="glassfish-tck-runner"/>
+            </then>
+            <else>
+                <mvn.dependency dir="glassfish-tck-runner"/>
+            </else>
+        </if>
+        <antcall target="copy.tck.ext.lib.jar"/>
+        <antcall target="clean"/>
+        <edit.domain.xml/>
+        <start.domain/>
+        <echo>Checking for a socket on ${admin.host} at port ${admin.port}, will wait up to ${wait.for.v4} seconds
+        </echo>
+        <waitfor maxwait="${wait.for.v4}" maxwaitunit="second" checkevery="1" checkeveryunit="second">
+            <socket server="${admin.host}" port="${admin.port}"/>
+        </waitfor>
+        <echo>Domain started.</echo>
+        <ant antfile="glassfish.xml" target="add.jvm.options"/>
+        <ant antfile="glassfish.xml" target="enable.jms"/>
+        <ant antfile="glassfish.xml" target="set.implicit.cdi"/>
+        <ant antfile="glassfish.xml" target="add.cdi.tck.users"/>
+
+        <antcall target="stop.javadb"/>
+        <antcall target="start.javadb"/>
+        <stop.domain/>
     </target>
 
 
@@ -462,10 +465,10 @@
 
     <presetdef name="mvn.dependency-tree">
         <exec executable="${maven.executable}">
-            <arg value="--global-settings" />
+            <arg value="--global-settings"/>
             <arg value="${porting.home}/settings.xml"/>
-            <arg value="-P" />
-            <arg value="payara-managed" />
+            <arg value="-P"/>
+            <arg value="payara-managed"/>
             <arg value="dependency:tree"/>
         </exec>
     </presetdef>
@@ -490,26 +493,26 @@
             <!--<arg value="-DtckTest=MessageDrivenBeanContextTest" />-->
         </exec>
     </presetdef>
-        
-        <presetdef name="mvn.install.win">
-		<exec executable="cmd">
-			<arg value="/c"/>
-                        <arg value="${maven.executable}.cmd"/>
-                        <arg value="install"/>
-		</exec>
-	</presetdef>
-	<presetdef name="mvn.dependency">
-		<exec executable="${maven.executable}">
-                        <arg value="--global-settings" />
-			            <arg value="${porting.home}/settings.xml" />
-                        <arg value="dependency:get" />
-						<arg value="-DrepositoryUrl=https://jakarta.oss.sonatype.org/content/repositories/releases"/>
-						<arg value="-DgroupId=jakarta.enterprise"/>
-						<arg value="-DartifactId=cdi-tck-ext-lib"/>
-						<arg value="-Dversion=${cdiext.version}"/>			
-                        <!-- <arg value="-DtckTest=MessageDrivenBeanContextTest" /> -->                      
-		</exec>
-	</presetdef>
+
+    <presetdef name="mvn.install.win">
+        <exec executable="cmd">
+            <arg value="/c"/>
+            <arg value="${maven.executable}.cmd"/>
+            <arg value="install"/>
+        </exec>
+    </presetdef>
+    <presetdef name="mvn.dependency">
+        <exec executable="${maven.executable}">
+            <arg value="--global-settings"/>
+            <arg value="${porting.home}/settings.xml"/>
+            <arg value="dependency:get"/>
+            <arg value="-DrepositoryUrl=https://jakarta.oss.sonatype.org/content/repositories/releases"/>
+            <arg value="-DgroupId=jakarta.enterprise"/>
+            <arg value="-DartifactId=cdi-tck-ext-lib"/>
+            <arg value="-Dversion=${cdiext.version}"/>
+            <!-- <arg value="-DtckTest=MessageDrivenBeanContextTest" /> -->
+        </exec>
+    </presetdef>
 
     <presetdef name="mvn.dependency.win">
         <exec executable="cmd">
@@ -522,5 +525,5 @@
             <arg value="-Dversion=${cdiext.version}"/>
         </exec>
     </presetdef>
-        
+
 </project>

--- a/common.xml
+++ b/common.xml
@@ -100,8 +100,8 @@
            <property name="exec.imqusermgr.part2" value="" />
            <property name="cert.file" value="${bin.dir}/certificates/cts_cert"/>
            <property name="server.config.dir.path" value="${server.domain}/${server.config.dir}" />
-           <property name="cacerts.jks" value="${server.config.dir.path}/cacerts.jks"/>
-           <property name="keystore.jks" value="${server.config.dir.path}/keystore.jks"/>
+           <property name="cacerts.jks" value="${server.config.dir.path}/cacerts.p12"/>
+           <property name="keystore.jks" value="${server.config.dir.path}/keystore.p12"/>
            <property name="cert8.db" value="${server.config.dir.path}/cert8.db"/>
            <property name="key3.db" value="${server.config.dir.path}/key3.db"/>
            <property name="secmod.db" value="${server.config.dir.path}/secmod.db"/>
@@ -134,8 +134,8 @@
            <property name="exec.imqusermgr.part2" value="/c ${imqbin.loc}\imqusermgr" />
            <property name="cert.file" value="${ts.home}\bin\certificates\cts_cert"/>
            <property name="server.config.dir.path" value="${server.domain}\${server.config.dir}" />
-           <property name="cacerts.jks" value="${server.config.dir.path}\cacerts.jks"/>
-           <property name="keystore.jks" value="${server.config.dir.path}\keystore.jks"/>
+           <property name="cacerts.jks" value="${server.config.dir.path}\cacerts.p12"/>
+           <property name="keystore.jks" value="${server.config.dir.path}\keystore.p12"/>
            <property name="cert8.db" value="${server.config.dir.path}\cert8.db"/>
            <property name="key3.db" value="${server.config.dir.path}\key3.db"/>
            <property name="secmod.db" value="${server.config.dir.path}\secmod.db"/>

--- a/common.xml
+++ b/common.xml
@@ -100,8 +100,8 @@
            <property name="exec.imqusermgr.part2" value="" />
            <property name="cert.file" value="${bin.dir}/certificates/cts_cert"/>
            <property name="server.config.dir.path" value="${server.domain}/${server.config.dir}" />
-           <property name="cacerts.jks" value="${server.config.dir.path}/cacerts.p12"/>
-           <property name="keystore.jks" value="${server.config.dir.path}/keystore.p12"/>
+           <property name="cacerts.jks" value="${server.config.dir.path}/cacerts.jks"/>
+           <property name="keystore.jks" value="${server.config.dir.path}/keystore.jks"/>
            <property name="cert8.db" value="${server.config.dir.path}/cert8.db"/>
            <property name="key3.db" value="${server.config.dir.path}/key3.db"/>
            <property name="secmod.db" value="${server.config.dir.path}/secmod.db"/>
@@ -134,8 +134,8 @@
            <property name="exec.imqusermgr.part2" value="/c ${imqbin.loc}\imqusermgr" />
            <property name="cert.file" value="${ts.home}\bin\certificates\cts_cert"/>
            <property name="server.config.dir.path" value="${server.domain}\${server.config.dir}" />
-           <property name="cacerts.jks" value="${server.config.dir.path}\cacerts.p12"/>
-           <property name="keystore.jks" value="${server.config.dir.path}\keystore.p12"/>
+           <property name="cacerts.jks" value="${server.config.dir.path}\cacerts.jks"/>
+           <property name="keystore.jks" value="${server.config.dir.path}\keystore.jks"/>
            <property name="cert8.db" value="${server.config.dir.path}\cert8.db"/>
            <property name="key3.db" value="${server.config.dir.path}\key3.db"/>
            <property name="secmod.db" value="${server.config.dir.path}\secmod.db"/>

--- a/docker/run_cditck.sh
+++ b/docker/run_cditck.sh
@@ -60,7 +60,9 @@ cat ${WORKSPACE}/docker/CDI.policy >> ${WORKSPACE}/payara6/glassfish/domains/dom
 #Edit test properties
 sed -i "s#porting.home=.*#porting.home=${TS_HOME}#g" ${TS_HOME}/build.properties
 sed -i "s#glassfish.home=.*#glassfish.home=${WORKSPACE}/payara6/glassfish#g" ${TS_HOME}/build.properties
-if [[ "${PROFILE}" == "web" || "${PROFILE}" == "WEB" ]]; then
+if [[ "${PROFILE}" == "core" || "${PROFILE}" == "CORE" ]]; then
+  sed -i "s#javaee.level=.*#javaee.level=core#g" ${TS_HOME}/build.properties
+elif [[ "${PROFILE}" == "web" || "${PROFILE}" == "WEB" ]]; then
   sed -i "s#javaee.level=.*#javaee.level=web#g" ${TS_HOME}/build.properties
 else
   sed -i "s#javaee.level=.*#javaee.level=full#g" ${TS_HOME}/build.properties

--- a/glassfish-tck-runner/pom.template.xml
+++ b/glassfish-tck-runner/pom.template.xml
@@ -393,6 +393,10 @@
                                 <dependency>jakarta.enterprise:cdi-tck-core-impl</dependency>
                                 <dependency>jakarta.enterprise:cdi-tck-web-impl</dependency>
                             </dependenciesToScan>
+                            <excludes>
+                                <exclude>org.jboss.cdi.tck.tests.event.observer.transactional.roolback.TransactionalObserverRollbackTest</exclude>
+                                <exclude>org.jboss.cdi.tck.tests.deployment.packaging.ejb.EJBJarDeploymentTest</exclude>
+                            </excludes>
                         </configuration>
                     </plugin>
                 </plugins>
@@ -430,6 +434,10 @@
                                 <dependency>jakarta.enterprise:cdi-tck-core-impl</dependency>
                                 <dependency>jakarta.enterprise:cdi-tck-web-impl</dependency>
                             </dependenciesToScan>
+                            <excludes>
+                                <exclude>org.jboss.cdi.tck.tests.event.observer.transactional.roolback.TransactionalObserverRollbackTest</exclude>
+                                <exclude>org.jboss.cdi.tck.tests.deployment.packaging.ejb.EJBJarDeploymentTest</exclude>
+                            </excludes>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/glassfish-tck-runner/pom.template.xml
+++ b/glassfish-tck-runner/pom.template.xml
@@ -354,8 +354,6 @@
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
                             <excludedGroups>cdi-full,se</excludedGroups>
-                            <!-- added following dependenciesToScan -->
-                            <!-- https://issues.apache.org/jira/browse/SUREFIRE-569 -->
                             <dependenciesToScan>
                                 <dependency>jakarta.enterprise:cdi-tck-core-impl</dependency>
                             </dependenciesToScan>
@@ -389,7 +387,6 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
-                        <version>3.0.0-M6</version>
                         <configuration>
                             <excludedGroups>javaee-full,se</excludedGroups>
                             <dependenciesToScan>

--- a/glassfish-tck-runner/pom.template.xml
+++ b/glassfish-tck-runner/pom.template.xml
@@ -192,6 +192,18 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>cdi-tck-lang-model</artifactId>
+            <version>${cdi.tck.version}</version>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <artifactId>container-se-api</artifactId>
+                    <groupId>org.jboss.arquillian.container</groupId>
+                </exclusion>
+            </exclusions>
+        </dependency>
 
         <dependency>
             <groupId>org.glassfish.hk2</groupId>

--- a/glassfish-tck-runner/pom.template.xml
+++ b/glassfish-tck-runner/pom.template.xml
@@ -270,9 +270,6 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
-                    <suiteXmlFiles>
-                        <suiteXmlFile>src/test/tck20/tck-tests.xml</suiteXmlFile>
-                    </suiteXmlFiles>
                     <!-- http://bugs.java.com/bugdatabase/view_bug.do?bug_id=4425695 -->
                     <argLine>-Xmx768m -Dsun.zip.disableMemoryMapping=true</argLine>
                     <forkMode>once</forkMode>
@@ -351,6 +348,9 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
+                            <suiteXmlFiles>
+                                <suiteXmlFile>src/test/tck20/tck-tests-core.xml</suiteXmlFile>
+                            </suiteXmlFiles>
                             <excludedGroups>cdi-full,se</excludedGroups>
                             <dependenciesToScan>
                                 <dependency>jakarta.enterprise:cdi-tck-core-impl</dependency>
@@ -386,15 +386,14 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
+                            <suiteXmlFiles>
+                                <suiteXmlFile>src/test/tck20/tck-tests.xml</suiteXmlFile>
+                            </suiteXmlFiles>
                             <excludedGroups>javaee-full,se</excludedGroups>
                             <dependenciesToScan>
                                 <dependency>jakarta.enterprise:cdi-tck-core-impl</dependency>
                                 <dependency>jakarta.enterprise:cdi-tck-web-impl</dependency>
                             </dependenciesToScan>
-                            <excludes>
-                                <exclude>org.jboss.cdi.tck.tests.event.observer.transactional.roolback.TransactionalObserverRollbackTest</exclude>
-                                <exclude>org.jboss.cdi.tck.tests.deployment.packaging.ejb.EJBJarDeploymentTest</exclude>
-                            </excludes>
                         </configuration>
                     </plugin>
                 </plugins>
@@ -427,15 +426,14 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
+                            <suiteXmlFiles>
+                                <suiteXmlFile>src/test/tck20/tck-tests.xml</suiteXmlFile>
+                            </suiteXmlFiles>
                             <excludedGroups>se</excludedGroups>
                             <dependenciesToScan>
                                 <dependency>jakarta.enterprise:cdi-tck-core-impl</dependency>
                                 <dependency>jakarta.enterprise:cdi-tck-web-impl</dependency>
                             </dependenciesToScan>
-                            <excludes>
-                                <exclude>org.jboss.cdi.tck.tests.event.observer.transactional.roolback.TransactionalObserverRollbackTest</exclude>
-                                <exclude>org.jboss.cdi.tck.tests.deployment.packaging.ejb.EJBJarDeploymentTest</exclude>
-                            </excludes>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/glassfish-tck-runner/pom.template.xml
+++ b/glassfish-tck-runner/pom.template.xml
@@ -196,20 +196,6 @@
         </dependency>
 
         <dependency>
-            <groupId>jakarta.enterprise</groupId>
-            <artifactId>cdi-tck-web-impl</artifactId>
-            <version>${cdi.tck.version}</version>
-            <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <artifactId>container-se-api</artifactId>
-                    <groupId>org.jboss.arquillian.container</groupId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-
-
-        <dependency>
             <groupId>org.glassfish.hk2</groupId>
             <artifactId>hk2-api</artifactId>
             <version>3.0.3</version>
@@ -236,8 +222,18 @@
         </dependency>
     </dependencies>
 
-
     <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>3.0.0-M6</version>
+                </plugin>
+            </plugins>
+
+        </pluginManagement>
+
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -275,8 +271,10 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.19.1</version>
                 <configuration>
+                    <suiteXmlFiles>
+                        <suiteXmlFile>src/test/tck20/tck-tests.xml</suiteXmlFile>
+                    </suiteXmlFiles>
                     <!-- http://bugs.java.com/bugdatabase/view_bug.do?bug_id=4425695 -->
                     <argLine>-Xmx768m -Dsun.zip.disableMemoryMapping=true</argLine>
                     <forkMode>once</forkMode>
@@ -286,12 +284,16 @@
                             <value>false</value>
                         </property>
                     </properties>
-                    <!-- added following dependenciesToScan -->
-                    <!-- https://issues.apache.org/jira/browse/SUREFIRE-569 -->
-                    <dependenciesToScan>
-                        <dependency>jakarta.enterprise:cdi-tck-core-impl</dependency>
-                        <dependency>jakarta.enterprise:cdi-tck-web-impl</dependency>
-                    </dependenciesToScan>
+                    <systemPropertyVariables>
+                        <arquillian.launch>weld</arquillian.launch>
+                        <org.jboss.cdi.tck.libraryDirectory>target/dependency/lib</org.jboss.cdi.tck.libraryDirectory>
+                        <org.jboss.cdi.tck.testDataSource>jdbc/__default</org.jboss.cdi.tck.testDataSource>
+                    </systemPropertyVariables>
+                    <systemProperties>
+                        <jacoco.agent>${jacoco.agent}</jacoco.agent>
+                        <additional.vm.args>${additional.vm.args}</additional.vm.args>
+                        <libPath>${project.build.outputDirectory}</libPath>
+                    </systemProperties>
                 </configuration>
             </plugin>
             <plugin>
@@ -342,6 +344,100 @@
     </build>
 
     <profiles>
+        <profile>
+            <id>core</id>
+
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <excludedGroups>cdi-full,se</excludedGroups>
+                            <!-- added following dependenciesToScan -->
+                            <!-- https://issues.apache.org/jira/browse/SUREFIRE-569 -->
+                            <dependenciesToScan>
+                                <dependency>jakarta.enterprise:cdi-tck-core-impl</dependency>
+                            </dependenciesToScan>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <profile>
+            <id>web</id>
+
+            <!-- Pull in the additional TCK artefact and scan it -->
+            <dependencies>
+                <dependency>
+                    <groupId>jakarta.enterprise</groupId>
+                    <artifactId>cdi-tck-web-impl</artifactId>
+                    <version>${cdi.tck.version}</version>
+                    <scope>test</scope>
+                    <exclusions>
+                        <exclusion>
+                            <artifactId>container-se-api</artifactId>
+                            <groupId>org.jboss.arquillian.container</groupId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+            </dependencies>
+
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <version>3.0.0-M6</version>
+                        <configuration>
+                            <excludedGroups>javaee-full,se</excludedGroups>
+                            <dependenciesToScan>
+                                <dependency>jakarta.enterprise:cdi-tck-core-impl</dependency>
+                                <dependency>jakarta.enterprise:cdi-tck-web-impl</dependency>
+                            </dependenciesToScan>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+
+        <profile>
+            <id>platform</id>
+
+            <!-- Pull in the additional TCK artefact and scan it -->
+            <dependencies>
+                <dependency>
+                    <groupId>jakarta.enterprise</groupId>
+                    <artifactId>cdi-tck-web-impl</artifactId>
+                    <version>${cdi.tck.version}</version>
+                    <scope>test</scope>
+                    <exclusions>
+                        <exclusion>
+                            <artifactId>container-se-api</artifactId>
+                            <groupId>org.jboss.arquillian.container</groupId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+            </dependencies>
+
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <excludedGroups>se</excludedGroups>
+                            <dependenciesToScan>
+                                <dependency>jakarta.enterprise:cdi-tck-core-impl</dependency>
+                                <dependency>jakarta.enterprise:cdi-tck-web-impl</dependency>
+                            </dependenciesToScan>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
 
         <profile>
             <id>payara-remote</id>
@@ -383,29 +479,6 @@
                         <directory>src/test/glassfish-managed</directory>
                     </resource>
                 </resources>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <version>3.0.0-M5</version>
-                        <configuration>
-                            <excludedGroups>se</excludedGroups>
-                            <suiteXmlFiles>
-                                <suiteXmlFile>src/test/tck20/tck-tests.xml</suiteXmlFile>
-                            </suiteXmlFiles>
-                            <systemPropertyVariables>
-                                <arquillian.launch>weld</arquillian.launch>
-                                <org.jboss.cdi.tck.libraryDirectory>target/dependency/lib</org.jboss.cdi.tck.libraryDirectory>
-                                <org.jboss.cdi.tck.testDataSource>jdbc/__default</org.jboss.cdi.tck.testDataSource>
-                            </systemPropertyVariables>
-                            <systemProperties>
-                                <jacoco.agent>${jacoco.agent}</jacoco.agent>
-                                <additional.vm.args>${additional.vm.args}</additional.vm.args>
-                                <libPath>${project.build.outputDirectory}</libPath>
-                            </systemProperties>
-                        </configuration>
-                    </plugin>
-                </plugins>
             </build>
         </profile>
 
@@ -497,43 +570,10 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
-                        <version>3.0.0-M5</version>
                         <configuration>
-                            <!--core profile-->
-                            <excludedGroups>cdi-full,se</excludedGroups>
-                            <dependenciesToScan>
-                                <dependency>jakarta.enterprise:cdi-tck-core-impl</dependency>
-                            </dependenciesToScan>
-
-                            <!--web profile-->
-                            <!--excludedGroups>javaee-full,se</excludedGroups>
-                            <dependenciesToScan>
-                                <dependency>jakarta.enterprise:cdi-tck-core-impl</dependency>
-                                <dependency>jakarta.enterprise:cdi-tck-web-impl</dependency>
-                            </dependenciesToScan-->
-
-                            <!-- Jakarta EE full -->
-                            <!--excludedGroups>se</excludedGroups-->
-                            <!--dependenciesToScan>
-                                <dependency>jakarta.enterprise:cdi-tck-core-impl</dependency>
-                                <dependency>jakarta.enterprise:cdi-tck-web-impl</dependency>
-                            </dependenciesToScan-->
-                            <suiteXmlFiles>
-                                <suiteXmlFile>src/test/tck20/tck-tests.xml</suiteXmlFile>
-                            </suiteXmlFiles>
                             <additionalClasspathElements>
                                 <additionalClasspathElement>${env.DIST}/${env.CDI_TCK_DIST}/artifacts/cdi-tck-impl-${env.CDI_TCK_VERSION}.jar</additionalClasspathElement>
                             </additionalClasspathElements>
-                            <systemPropertyVariables>
-                                <arquillian.launch>weld</arquillian.launch>
-                                <org.jboss.cdi.tck.libraryDirectory>target/dependency/lib</org.jboss.cdi.tck.libraryDirectory>
-                                <org.jboss.cdi.tck.testDataSource>jdbc/__default</org.jboss.cdi.tck.testDataSource>
-                            </systemPropertyVariables>
-                            <systemProperties>
-                                <jacoco.agent>${jacoco.agent}</jacoco.agent>
-                                <additional.vm.args>${additional.vm.args}</additional.vm.args>
-                                <libPath>${project.build.outputDirectory}</libPath>
-                            </systemProperties>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/glassfish-tck-runner/pom.template.xml
+++ b/glassfish-tck-runner/pom.template.xml
@@ -168,8 +168,6 @@
             <groupId>jakarta.enterprise</groupId>
             <artifactId>cdi-tck-core-impl</artifactId>
             <version>${cdi.tck.version}</version>
-            <type>xml</type>
-            <classifier>suite</classifier>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/glassfish-tck-runner/src/test/glassfish-managed/arquillian.template.xml
+++ b/glassfish-tck-runner/src/test/glassfish-managed/arquillian.template.xml
@@ -21,11 +21,6 @@
             xmlns="http://jboss.org/schema/arquillian"
             xsi:schemaLocation="http://jboss.org/schema/arquillian
 http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
-
-    <engine>
-        <!--<property name="deploymentExportPath">target/artifacts</property>-->
-        <property name="maxTestClassesBeforeRestart">@maxClassesRestart@</property>
-    </engine>
     
     <container qualifier="weld">
         <configuration>

--- a/glassfish-tck-runner/src/test/java/org/jboss/weld/langmodel/tck/LangModelExtension.java
+++ b/glassfish-tck-runner/src/test/java/org/jboss/weld/langmodel/tck/LangModelExtension.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright \(c\) "2022" Red Hat and others
+ *
+ * This program and the accompanying materials are made available under the Apache Software License 2.0 which is available at:
+ *  https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.jboss.weld.langmodel.tck;
+
+
+import jakarta.enterprise.inject.build.compatible.spi.BuildCompatibleExtension;
+import jakarta.enterprise.inject.build.compatible.spi.Enhancement;
+import jakarta.enterprise.lang.model.declarations.ClassInfo;
+import org.jboss.cdi.lang.model.tck.LangModelVerifier;
+
+public class LangModelExtension implements BuildCompatibleExtension {
+
+    public static int ENHANCEMENT_INVOKED = 0;
+
+    @Enhancement(types = LangModelVerifier.class)
+    public void run(ClassInfo clazz) {
+        ENHANCEMENT_INVOKED++;
+        LangModelVerifier.verify(clazz);
+    }
+}

--- a/glassfish-tck-runner/src/test/java/org/jboss/weld/langmodel/tck/LangModelTckTest.java
+++ b/glassfish-tck-runner/src/test/java/org/jboss/weld/langmodel/tck/LangModelTckTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright \(c\) "2022" Red Hat and others
+ *
+ * This program and the accompanying materials are made available under the Apache Software License 2.0 which is available at:
+ *  https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.jboss.weld.langmodel.tck;
+
+import jakarta.enterprise.inject.build.compatible.spi.BuildCompatibleExtension;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.cdi.lang.model.tck.LangModelVerifier;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.BeanDiscoveryMode;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.impl.BeansXml;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * <p>
+ * Executes CDI TCK for language model used in CDI Lite, current setup requires discovery mode ALL plus adding
+ * {@link LangModelVerifier} into the deployment to discover it as a bean. Alternatively, this could be added
+ * synthetically inside {@link LangModelExtension}.
+ * </p>
+ *
+ * <p>
+ * Actual test happens inside {@link LangModelExtension} by calling {@link LangModelVerifier#verify(ClassInfo)}.
+ * </p>
+ */
+@RunWith(Arquillian.class)
+public class LangModelTckTest {
+
+    @Deployment
+    public static Archive<?> deploy() {
+        return ShrinkWrap.create(WebArchive.class, LangModelTckTest.class.getSimpleName() + ".war")
+                // beans.xml with discovery mode "all"
+                .addAsWebInfResource(new BeansXml(BeanDiscoveryMode.ALL), "beans.xml")
+                .addAsServiceProvider(BuildCompatibleExtension.class, LangModelExtension.class)
+                // add this class into the deployment so that it's subject to discovery
+                .addClasses(LangModelVerifier.class);
+    }
+
+    @Test
+    public void testLangModel() {
+        // test is executed in LangModelExtension; here we just assert that the relevant extension method was invoked
+        Assert.assertTrue(LangModelExtension.ENHANCEMENT_INVOKED == 1);
+    }
+}

--- a/glassfish-tck-runner/src/test/tck20/tck-tests-core.xml
+++ b/glassfish-tck-runner/src/test/tck20/tck-tests-core.xml
@@ -22,21 +22,6 @@
             <package name="org.jboss.cdi.tck.interceptors.tests.*" />
         </packages>
 
-        <classes>
-            <!-- CDITCK-587 -->
-            <class name="org.jboss.cdi.tck.tests.event.observer.transactional.roolback.TransactionalObserverRollbackTest">
-                <methods>
-                    <exclude name=".*"/>
-                </methods>
-            </class>
-
-            <!-- CDITCK-597 -->
-            <class name="org.jboss.cdi.tck.tests.deployment.packaging.ejb.EJBJarDeploymentTest">
-                <methods>
-                    <exclude name=".*"/>
-                </methods>
-            </class>
-        </classes>
     </test>
 
 </suite>

--- a/glassfish-tck-runner/src/test/tck20/tck-tests.xml
+++ b/glassfish-tck-runner/src/test/tck20/tck-tests.xml
@@ -36,6 +36,30 @@
                     <exclude name=".*"/>
                 </methods>
             </class>
+
+            <!-- https://github.com/jakartaee/cdi-tck/issues/389 -->
+	    <class name="org.jboss.cdi.tck.tests.context.application.async.ApplicationContextAsyncListenerTest">
+	        <methods>
+		    <exclude name="testApplicationContextActiveOnError"/>
+		</methods>
+	    </class>
+	    <class name="org.jboss.cdi.tck.tests.context.conversation.determination.ConversationDeterminationTest">
+                <methods>
+                    <exclude name="testConversationDetermination"/>
+                </methods>
+            </class>
+	    <class name="org.jboss.cdi.tck.tests.context.request.async.RequestContextAsyncListenerTest">
+                <methods>
+                    <exclude name="testRequestContextActiveOnError"/>
+                </methods>
+            </class>
+	    <class name="org.jboss.cdi.tck.tests.context.session.async.SessionContextAsyncListenerTest">
+                <methods>
+                    <exclude name="testSessionContextActiveOnError"/>
+                </methods>
+            </class>
+
+
         </classes>
     </test>
 

--- a/glassfish-tck-runner/src/test/tck20/tck-tests.xml
+++ b/glassfish-tck-runner/src/test/tck20/tck-tests.xml
@@ -22,24 +22,6 @@
             <package name="org.jboss.cdi.tck.interceptors.tests.*" />
         </packages>
 
-        <classes>
-
-            <!-- CDITCK-587 -->
-            <class name="org.jboss.cdi.tck.tests.event.observer.transactional.roolback.TransactionalObserverRollbackTest">
-                <methods>
-                    <exclude name=".*"/>
-                </methods>
-            </class>
-
-            <!-- CDITCK-597 -->
-            <class name="org.jboss.cdi.tck.tests.deployment.packaging.ejb.EJBJarDeploymentTest">
-                <methods>
-                    <exclude name=".*"/>
-                </methods>
-            </class>
-
-        </classes>
-
     </test>
 
 </suite>


### PR DESCRIPTION
Updates for running the TCK against EE 10 Core, Web Profile, and Platform.

Edit the `build.properties` file with the path to your Payara install (`glassfish.home`) and with which level you wish to run against (`javaee.level`) with _core_, _web_, or _full_.

Then run `ant test`. After it's done its initial run to perform various bits of config, you can rerun individual tests against managed or remote profile by moving into `glassfish-tck-runner` and executing `mvn clean test` with the following options:
* Profiles
  * TCK type: `core`, `web`, `platform`
  * Server type: `payara-remote`, `payara-managed`

You can then specify individual tests in the usual maven way.

Example: `mvn clean test -Ppayara-remote,platform -Dorg.jboss.cdi.tck.tests.extensions.lifecycle.processInjectionTarget.ContainerEventTest`