### PR TITLE
Fish-6081: Upgrading cdi tck version

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -51,5 +51,5 @@ max.perm.gen.size=1024m
 # found under ${porting.home}/glassfish-tck-runner/target/surefire-reports
 ######################################################
 report.dir=${porting.home}/reports
-cdiextjar=cdi-tck-ext-lib-4.0.5.jar
-cdiext.version=4.0.5
+cdiextjar=cdi-tck-ext-lib-4.0.6.jar
+cdiext.version=4.0.6

--- a/glassfish-tck-runner/pom.template.xml
+++ b/glassfish-tck-runner/pom.template.xml
@@ -42,7 +42,7 @@
         <shrinkwrap.version>1.2.6</shrinkwrap.version>
         <minimum.maven.version>3.0.5</minimum.maven.version>
         <cdi.api.version>4.0.1</cdi.api.version>
-        <cdi.tck.version>4.0.5</cdi.tck.version>
+        <cdi.tck.version>4.0.6</cdi.tck.version>
         <httpcomponents.version>4.5.5</httpcomponents.version>
         <arquillian.version>1.7.0.Alpha10</arquillian.version>
         <jakarta.platform.version>10.0.0-RC1</jakarta.platform.version>

--- a/glassfish-tck-runner/src/test/tck20/tck-tests.xml
+++ b/glassfish-tck-runner/src/test/tck20/tck-tests.xml
@@ -37,29 +37,6 @@
                 </methods>
             </class>
 
-            <!-- https://github.com/jakartaee/cdi-tck/issues/389 -->
-	    <class name="org.jboss.cdi.tck.tests.context.application.async.ApplicationContextAsyncListenerTest">
-	        <methods>
-		    <exclude name="testApplicationContextActiveOnError"/>
-		</methods>
-	    </class>
-	    <class name="org.jboss.cdi.tck.tests.context.conversation.determination.ConversationDeterminationTest">
-                <methods>
-                    <exclude name="testConversationDetermination"/>
-                </methods>
-            </class>
-	    <class name="org.jboss.cdi.tck.tests.context.request.async.RequestContextAsyncListenerTest">
-                <methods>
-                    <exclude name="testRequestContextActiveOnError"/>
-                </methods>
-            </class>
-	    <class name="org.jboss.cdi.tck.tests.context.session.async.SessionContextAsyncListenerTest">
-                <methods>
-                    <exclude name="testSessionContextActiveOnError"/>
-                </methods>
-            </class>
-
-
         </classes>
     </test>
 


### PR DESCRIPTION
Upgrading cdi-tck to last version listed here:
[4.0.6](https://download.eclipse.org/jakartaee/cdi/4.0/) 
also removing skipped test reported on the following challenge:
[challenge](https://github.com/jakartaee/cdi-tck/issues/389)
this challenge was revoked but the changes were added as an improvement for the cdi-tck functionality on the following PR:
[PR](https://github.com/jakartaee/cdi-tck/pull/399)
result from tests:
core profile execution:
`[mvn.test] [INFO] Tests run: 725, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 232.572 s - in TestSuite
 [mvn.test] [INFO]
 [mvn.test] [INFO] Results:
 [mvn.test] [INFO]
 [mvn.test] [INFO] Tests run: 725, Failures: 0, Errors: 0, Skipped: 0`
web profile execution:
` [mvn.test] [INFO] Tests run: 1701, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 685.773 s - in TestSuite
 [mvn.test] [INFO]
 [mvn.test] [INFO] Results:
 [mvn.test] [INFO]
 [mvn.test] [INFO] Tests run: 1701, Failures: 0, Errors: 0, Skipped: 0`

full profile execution:
`[mvn.test] [INFO] Tests run: 1831, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 927.868 s - in TestSuite
 [mvn.test] [INFO]
 [mvn.test] [INFO] Results:
 [mvn.test] [INFO]
 [mvn.test] [INFO] Tests run: 1831, Failures: 0, Errors: 0, Skipped: 0`