### PR TITLE
FISH-9109: adding improvements to execute cdi tck

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -2,7 +2,7 @@
 <!--
 
     Copyright (c) 2018, 2021 Oracle and/or its affiliates. All rights reserved.
-    Copyright (c) 2019, 2020 Payara Foundation and/or its affiliates. All rights reserved.
+    Copyright (c) 2019, 2024 Payara Foundation and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -82,6 +82,7 @@
             </then>
             <else>
                 <echo message="################# Dependencies at: ${env.DIST}/${env.CDI_TCK_DIST}/artifacts/cdi-tck-impl-${env.CDI_TCK_VERSION}.jar #################"/>
+                <mvn.package dir="glassfish-tck-runner"/>
                 <mvn.test dir="glassfish-tck-runner"/>
                 <mvn.dependency-tree dir="glassfish-tck-runner"/>
             </else>
@@ -463,7 +464,6 @@
             <arg value="-P"/>
             <arg value="${profiles}"/>
             <arg value="-U"/>
-            <arg value="clean"/>
             <arg value="test"/>
         </exec>
     </presetdef>
@@ -503,10 +503,10 @@
         </exec>
     </presetdef>
 
-    <presetdef name="mvn.install">
+    <presetdef name="mvn.package">
         <exec executable="${maven.executable}">
-            <arg value="install"/>
-            <!--<arg value="-DtckTest=MessageDrivenBeanContextTest" />-->
+            <arg value="clean"/>
+            <arg value="package"/>
         </exec>
     </presetdef>
 
@@ -526,7 +526,6 @@
             <arg value="-DgroupId=jakarta.enterprise"/>
             <arg value="-DartifactId=cdi-tck-ext-lib"/>
             <arg value="-Dversion=${cdiext.version}"/>
-            <!-- <arg value="-DtckTest=MessageDrivenBeanContextTest" /> -->
         </exec>
     </presetdef>
 

--- a/glassfish-tck-runner/pom.template.xml
+++ b/glassfish-tck-runner/pom.template.xml
@@ -1,7 +1,7 @@
 <!--
 
     Copyright (c) 2018, 2021 Oracle and/or its affiliates. All rights reserved.
-    Copyright (c) 2019, 2022 Payara Foundation and/or its affiliates. All rights reserved.
+    Copyright (c) 2019, 2024 Payara Foundation and/or its affiliates. All rights reserved.
     
 	This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -20,12 +20,12 @@
     <parent>
         <artifactId>weld-core-parent</artifactId>
         <groupId>org.jboss.weld</groupId>
-        <version>5.0.0.SP2</version>
+        <version>6.0.0.Beta4</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>weld-payara-runner-tck</artifactId>
-    <name>CDI TCK runner 4.0 for Weld (Payara)</name>
+    <name>CDI TCK runner 4.1 for Weld (Payara)</name>
     <description>Aggregates dependencies and runs the CDI TCK (both standalone and on GlassFish AS)</description>
 
     <licenses>
@@ -39,27 +39,18 @@
 
     <properties>
         <htmlunit.version>2.50.0</htmlunit.version>
-        <shrinkwrap.version>1.2.6</shrinkwrap.version>
-        <minimum.maven.version>3.0.5</minimum.maven.version>
         <cdi.api.version>4.1.0</cdi.api.version>
         <cdi.tck.version>4.1.0</cdi.tck.version>
-        <httpcomponents.version>4.5.5</httpcomponents.version>
         <arquillian.version>1.8.0.Final</arquillian.version>
-        <jaxws-api.version>4.0.1</jaxws-api.version>
-        <jakarta.annotation-api.version>3.0.0</jakarta.annotation-api.version>
-        <jakarta.interceptor-api.version>2.2.0</jakarta.interceptor-api.version>
-        <jakarta.faces-api.version>4.0.1</jakarta.faces-api.version>
+        <minimum.maven.version>3.0.5</minimum.maven.version>
         <jakarta.resource-api.version>2.1.0</jakarta.resource-api.version>
         <jaxb-api.version>4.0.1</jaxb-api.version>
         <jms-api.version>3.1.0</jms-api.version>
-        <jsonp-api.version>2.1.0</jsonp-api.version>
-        <hk2-api.version>3.0.4</hk2-api.version>
-        <jersey.version>3.1.5</jersey.version>
-        <jersey-media.version>3.1.2</jersey-media.version>
-        <jakarta-el.version>5.0.0-M1</jakarta-el.version>
-        <arquillian-payara.version>3.0.alpha6</arquillian-payara.version>
-        <jersey-hk2.version>3.1.5.payara-p1</jersey-hk2.version>
-        <hk2-locator.version>3.0.2</hk2-locator.version>
+        <expressly.version>6.0.0-M1</expressly.version>
+        <arquillian-payara.version>4.0.alpha1</arquillian-payara.version>
+        <testng.version>7.9.0</testng.version>
+        <commons.version>2.6</commons.version>
+        <weld-version>6.0.0.Beta4</weld-version>
     </properties>
 
     <dependencyManagement>
@@ -71,31 +62,11 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
-            <dependency>
-                <groupId>jakarta.xml.ws</groupId>
-                <artifactId>jakarta.xml.ws-api</artifactId>
-                <version>${jaxws-api.version}</version>
-            </dependency>
         </dependencies>
     </dependencyManagement>
 
     <dependencies>
         <!--jakarta dependencies for cdi tck api-->
-        <dependency>
-            <groupId>jakarta.annotation</groupId>
-            <artifactId>jakarta.annotation-api</artifactId>
-            <version>${jakarta.annotation-api.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>jakarta.interceptor</groupId>
-            <artifactId>jakarta.interceptor-api</artifactId>
-            <version>${jakarta.interceptor-api.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>jakarta.faces</groupId>
-            <artifactId>jakarta.faces-api</artifactId>
-            <version>${jakarta.faces-api.version}</version>
-        </dependency>
         <dependency>
             <groupId>jakarta.resource</groupId>
             <artifactId>jakarta.resource-api</artifactId>
@@ -112,68 +83,85 @@
             <version>${jms-api.version}</version>
         </dependency>
         <dependency>
-            <groupId>jakarta.json</groupId>
-            <artifactId>jakarta.json-api</artifactId>
-            <version>${jsonp-api.version}</version>
-        </dependency>
-        <dependency>
             <groupId>jakarta.enterprise</groupId>
             <artifactId>jakarta.enterprise.cdi-api</artifactId>
             <version>${cdi.api.version}</version>
         </dependency>
         <dependency>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-el-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.el</groupId>
+            <artifactId>jakarta.el-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <!--weld section-->
+        <dependency>
+            <groupId>org.jboss.weld</groupId>
+            <artifactId>weld-api</artifactId>
+            <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.weld</groupId>
+            <artifactId>weld-spi</artifactId>
+            <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
             <groupId>org.jboss.weld</groupId>
             <artifactId>weld-core-impl</artifactId>
+            <scope>provided</scope>
             <exclusions>
                 <exclusion>
-                    <groupId>org.testng</groupId>
-                    <artifactId>testng</artifactId>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
                 </exclusion>
             </exclusions>
-        </dependency>
-
-        <dependency>
-            <groupId>org.jboss.weld.module</groupId>
-            <artifactId>weld-jsf</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.testng</groupId>
-                    <artifactId>testng</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.weld.module</groupId>
-            <artifactId>weld-ejb</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jboss.weld.module</groupId>
             <artifactId>weld-web</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.glassfish.cdi</groupId>
-            <artifactId>gf-cdi-porting-package-tck</artifactId>
-            <version>4.0</version>
+            <scope>provided</scope>
             <exclusions>
                 <exclusion>
-                    <groupId>org.jboss.weld</groupId>
-                    <artifactId>weld-osgi-bundle</artifactId>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
-
         <dependency>
             <groupId>jakarta.enterprise</groupId>
             <artifactId>cdi-tck-api</artifactId>
             <version>${cdi.tck.version}</version>
             <exclusions>
                 <exclusion>
-                    <artifactId>jakarta.el-api</artifactId>
-                    <groupId>jakarta.el</groupId>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
                 </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>cdi-tck-core-impl</artifactId>
+            <version>${cdi.tck.version}</version>
+            <scope>test</scope>
+            <exclusions>
                 <exclusion>
-                    <artifactId>jakarta.faces-api</artifactId>
-                    <groupId>jakarta.faces</groupId>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -182,102 +170,103 @@
             <groupId>jakarta.enterprise</groupId>
             <artifactId>cdi-tck-core-impl</artifactId>
             <version>${cdi.tck.version}</version>
+            <type>xml</type>
+            <classifier>suite</classifier>
             <scope>test</scope>
             <exclusions>
                 <exclusion>
-                    <artifactId>container-se-api</artifactId>
-                    <groupId>org.jboss.arquillian.container</groupId>
-                </exclusion>
-                <exclusion>
-                    <artifactId>httpcore</artifactId>
-                    <groupId>org.apache.httpcomponents</groupId>
-                </exclusion>
-                <exclusion>
-                    <artifactId>httpmime</artifactId>
-                    <groupId>org.apache.httpcomponents</groupId>
-                </exclusion>
-                <exclusion>
-                    <artifactId>httpclient</artifactId>
-                    <groupId>org.apache.httpcomponents</groupId>
-                </exclusion>
-                <exclusion>
-                    <artifactId>jaxrs-api</artifactId>
-                    <groupId>org.jboss.resteasy</groupId>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
-
         <dependency>
-            <groupId>org.glassfish.hk2</groupId>
-            <artifactId>hk2-api</artifactId>
-            <version>${hk2-api.version}</version>
+            <groupId>org.glassfish.expressly</groupId>
+            <artifactId>expressly</artifactId>
+            <version>${expressly.version}</version>
+            <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
-            <groupId>org.glassfish.jersey.inject</groupId>
-            <artifactId>jersey-hk2</artifactId>
-            <version>${jersey.version}</version>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <version>${testng.version}</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.glassfish.jersey.core</groupId>
-            <artifactId>jersey-client</artifactId>
-            <version>${jersey.version}</version>
+            <groupId>org.jboss.weld</groupId>
+            <artifactId>weld-lite-extension-translator</artifactId>
+            <version>${weld-version}</version>
         </dependency>
         <dependency>
-            <groupId>org.glassfish.jersey.media</groupId>
-            <artifactId>jersey-media-multipart</artifactId>
-            <version>${jersey-media.version}</version>
+            <groupId>commons-lang</groupId>
+            <artifactId>commons-lang</artifactId>
+            <version>${commons.version}</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.glassfish</groupId>
-            <artifactId>jakarta.el</artifactId>
-            <version>${jakarta-el.version}</version>
+            <groupId>org.jboss.arquillian.testng</groupId>
+            <artifactId>arquillian-testng-container</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.shrinkwrap.descriptors</groupId>
+            <artifactId>shrinkwrap-descriptors-impl-javaee</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>fish.payara.arquillian</groupId>
+            <artifactId>arquillian-payara-server-managed</artifactId>
+            <version>${arquillian-payara.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>net.sourceforge.htmlunit</groupId>
+            <artifactId>htmlunit</artifactId>
+            <version>${htmlunit.version}</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 
     <build>
-        <pluginManagement>
-            <plugins>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-surefire-plugin</artifactId>
-                    <version>3.0.0-M6</version>
-                </plugin>
-            </plugins>
-
-        </pluginManagement>
-
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-dependency-plugin</artifactId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <configuration>
+                    <!-- Disable annotation processor for test sources -->
+                    <testCompilerArgument>-proc:none</testCompilerArgument>
+                    <source>17</source>
+                    <target>17</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.4.2</version>
                 <executions>
                     <execution>
-                        <id>copy-weld-dependencies</id>
-                        <phase>process-resources</phase>
+                        <phase>test</phase>
                         <goals>
-                            <goal>copy-dependencies</goal>
+                            <goal>test-jar</goal>
                         </goals>
                         <configuration>
-                            <includeGroupIds>org.glassfish.cdi</includeGroupIds>
-                            <includeArtifactIds>gf-cdi-porting-package-tck</includeArtifactIds>
-                            <stripVersion>true</stripVersion>
-                            <overWriteReleases>true</overWriteReleases>
+                            <testClassesDirectory>${project.build.directory}/test-classes</testClassesDirectory>
                             <outputDirectory>${project.build.directory}/dependency/lib</outputDirectory>
+                            <archive>
+                                <manifest>
+                                    <addClasspath>false</addClasspath>
+                                </manifest>
+                            </archive>
+                            <classifier>testContent</classifier>
                         </configuration>
                     </execution>
-                    <execution>
-                            <id>copy-suite</id>
-                            <phase>process-resources</phase>
-                            <goals>
-                                <goal>copy-dependencies</goal>
-                            </goals>
-                            <configuration>
-                                <includeClassifiers>suite</includeClassifiers>
-                                <stripVersion>true</stripVersion>
-                                <overWriteReleases>true</overWriteReleases>
-                                <outputDirectory>${project.build.directory}/</outputDirectory>
-                            </configuration>
-                        </execution>                    
                 </executions>
             </plugin>
             <plugin>
@@ -340,16 +329,16 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
-                <configuration>
-                    <!-- Disable annotation processor for test sources -->
-                    <testCompilerArgument>-proc:none</testCompilerArgument>
-                </configuration>
-            </plugin>
+
         </plugins>
+        <resources>
+            <resource>
+                <directory>src/test/resources</directory>
+            </resource>
+            <resource>
+                <directory>src/test/glassfish-managed</directory>
+            </resource>
+        </resources>
     </build>
 
     <profiles>
@@ -374,66 +363,8 @@
                 </plugins>
             </build>
         </profile>
-
-        <profile>
-            <id>web</id>
-
-            <!-- Pull in the additional TCK artefact and scan it -->
-            <dependencies>
-                <dependency>
-                    <groupId>jakarta.enterprise</groupId>
-                    <artifactId>cdi-tck-web-impl</artifactId>
-                    <version>${cdi.tck.version}</version>
-                    <scope>test</scope>
-                    <exclusions>
-                        <exclusion>
-                            <artifactId>container-se-api</artifactId>
-                            <groupId>org.jboss.arquillian.container</groupId>
-                        </exclusion>
-                    </exclusions>
-                </dependency>
-            </dependencies>
-
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <suiteXmlFiles>
-                                <suiteXmlFile>src/test/tck20/tck-tests.xml</suiteXmlFile>
-                            </suiteXmlFiles>
-                            <excludedGroups>javaee-full,se</excludedGroups>
-                            <dependenciesToScan>
-                                <dependency>jakarta.enterprise:cdi-tck-core-impl</dependency>
-                                <dependency>jakarta.enterprise:cdi-tck-web-impl</dependency>
-                            </dependenciesToScan>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-
-
         <profile>
             <id>platform</id>
-
-            <!-- Pull in the additional TCK artefact and scan it -->
-            <dependencies>
-                <dependency>
-                    <groupId>jakarta.enterprise</groupId>
-                    <artifactId>cdi-tck-web-impl</artifactId>
-                    <version>${cdi.tck.version}</version>
-                    <scope>test</scope>
-                    <exclusions>
-                        <exclusion>
-                            <artifactId>container-se-api</artifactId>
-                            <groupId>org.jboss.arquillian.container</groupId>
-                        </exclusion>
-                    </exclusions>
-                </dependency>
-            </dependencies>
-
             <build>
                 <plugins>
                     <plugin>
@@ -446,7 +377,6 @@
                             <excludedGroups>se</excludedGroups>
                             <dependenciesToScan>
                                 <dependency>jakarta.enterprise:cdi-tck-core-impl</dependency>
-                                <dependency>jakarta.enterprise:cdi-tck-web-impl</dependency>
                             </dependenciesToScan>
                         </configuration>
                     </plugin>
@@ -458,16 +388,6 @@
             <id>payara-remote</id>
 
             <dependencies>
-                <dependency>
-                    <groupId>org.glassfish.jersey.inject</groupId>
-                    <artifactId></artifactId>
-                    <version>${jersey-hk2.version}</version>
-                </dependency>
-                <dependency>
-                    <groupId>org.glassfish.hk2</groupId>
-                    <artifactId>hk2-locator</artifactId>
-                    <version>${hk2-locator.version}</version>
-                </dependency>
                 <dependency>
                     <groupId>fish.payara.arquillian</groupId>
                     <artifactId>arquillian-payara-server-remote</artifactId>
@@ -485,16 +405,6 @@
                 </dependency>
 
             </dependencies>
-            <build>
-                <resources>
-                    <resource>
-                        <directory>src/test/resources</directory>
-                    </resource>
-                    <resource>
-                        <directory>src/test/glassfish-managed</directory>
-                    </resource>
-                </resources>
-            </build>
         </profile>
 
         <profile>
@@ -505,12 +415,6 @@
 
             <dependencies>
                 <dependency>
-                    <groupId>fish.payara.arquillian</groupId>
-                    <artifactId>arquillian-payara-server-managed</artifactId>
-                    <version>${arquillian-payara.version}</version>
-                    <scope>test</scope>
-                </dependency>
-                <dependency>
                     <groupId>org.jboss.arquillian.protocol</groupId>
                     <artifactId>arquillian-protocol-servlet-jakarta</artifactId>
                     <scope>test</scope>
@@ -519,80 +423,7 @@
                     <groupId>log4j</groupId>
                     <artifactId>log4j</artifactId>
                 </dependency>
-                <dependency>
-                    <groupId>org.jboss.arquillian.testng</groupId>
-                    <artifactId>arquillian-testng-container</artifactId>
-                    <scope>test</scope>
-                </dependency>
-                <dependency>
-                    <groupId>org.testng</groupId>
-                    <artifactId>testng</artifactId>
-                    <version>7.4.0</version>
-                    <scope>test</scope>
-                </dependency>
-                <dependency>
-                    <groupId>jakarta.enterprise</groupId>
-                    <artifactId>cdi-tck-core-impl</artifactId>
-                    <version>${cdi.tck.version}</version>
-                    <scope>test</scope>
-                </dependency>
-                <dependency>
-                    <groupId>jakarta.servlet</groupId>
-                    <artifactId>jakarta.servlet-api</artifactId>
-                    <version>6.0.0</version>
-                    <scope>test</scope>
-                </dependency>
-                <dependency>
-                    <groupId>jakarta.servlet.jsp</groupId>
-                    <artifactId>jakarta.servlet.jsp-api</artifactId>
-                    <version>3.1.0</version>
-                    <scope>test</scope>
-                </dependency>
-                <dependency>
-                    <groupId>org.jboss.shrinkwrap</groupId>
-                    <artifactId>shrinkwrap-api</artifactId>
-                    <version>${shrinkwrap.version}</version>
-                    <scope>test</scope>
-                </dependency>
-                <dependency>
-                    <groupId>org.jboss.shrinkwrap.descriptors</groupId>
-                    <artifactId>shrinkwrap-descriptors-api-javaee</artifactId>
-                    <version>2.0.0</version>
-                    <scope>test</scope>
-                </dependency>
-                <dependency>
-                    <groupId>org.jboss.shrinkwrap.descriptors</groupId>
-                    <artifactId>shrinkwrap-descriptors-impl-javaee</artifactId>
-                    <version>2.0.0</version>
-                    <scope>test</scope>
-                </dependency>
-                <dependency>
-                    <groupId>net.sourceforge.htmlunit</groupId>
-                    <artifactId>htmlunit</artifactId>
-                    <version>${htmlunit.version}</version>
-                </dependency>
             </dependencies>
-            <build>
-                <resources>
-                    <resource>
-                        <directory>src/test/resources</directory>
-                    </resource>
-                    <resource>
-                        <directory>src/test/glassfish-managed</directory>
-                    </resource>
-                </resources>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <additionalClasspathElements>
-                                <additionalClasspathElement>${env.DIST}/${env.CDI_TCK_DIST}/artifacts/cdi-tck-impl-${env.CDI_TCK_VERSION}.jar</additionalClasspathElement>
-                            </additionalClasspathElements>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
         </profile>
     </profiles>
 

--- a/glassfish-tck-runner/src/test/java/org/jboss/weld/tck/glassfish/GlassFishBeansImpl.java
+++ b/glassfish-tck-runner/src/test/java/org/jboss/weld/tck/glassfish/GlassFishBeansImpl.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2024 Eclipse Foundation and/or its affiliates.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+// Portions Copyright [2024] [Payara Foundation and/or its affiliates]
+package org.jboss.weld.tck.glassfish;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+import org.jboss.cdi.tck.spi.Beans;
+
+public class GlassFishBeansImpl implements Beans {
+
+    private Object fakeSerialized;
+
+    @Override
+    public boolean isProxy(Object instance) {
+        return instance.getClass().getName().indexOf("_$$_Weld") > 0;
+    }
+
+    @Override
+    public byte[] passivate(Object instance) throws IOException {
+        fakeSerialized = instance;
+        return instance.toString().getBytes();
+    }
+
+    @Override
+    public Object activate(byte[] bytes) throws IOException, ClassNotFoundException {
+        if (Arrays.equals(fakeSerialized.toString().getBytes(), bytes)) {
+            Object result = fakeSerialized;
+            fakeSerialized = null;
+            return result;
+        }
+        return null;
+    }
+}

--- a/glassfish-tck-runner/src/test/java/org/jboss/weld/tck/glassfish/GlassFishContextImpl.java
+++ b/glassfish-tck-runner/src/test/java/org/jboss/weld/tck/glassfish/GlassFishContextImpl.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2024 Eclipse Foundation and/or its affiliates.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+// Portions Copyright [2024] [Payara Foundation and/or its affiliates]
+package org.jboss.weld.tck.glassfish;
+
+import jakarta.enterprise.context.spi.Context;
+
+import org.jboss.cdi.tck.spi.Contexts;
+import org.jboss.weld.Container;
+import org.jboss.weld.context.ApplicationContext;
+import org.jboss.weld.context.DependentContext;
+import org.jboss.weld.context.ManagedContext;
+import org.jboss.weld.context.RequestContext;
+import org.jboss.weld.context.http.HttpRequestContext;
+import org.jboss.weld.util.ForwardingContext;
+
+public class GlassFishContextImpl implements Contexts<Context> {
+    @Override
+    public RequestContext getRequestContext() {
+        return Container.instance().deploymentManager().instance().select(HttpRequestContext.class).get();
+    }
+
+    @Override
+    public void setActive(Context context) {
+        context = ForwardingContext.unwrap(context);
+        if (context instanceof ManagedContext) {
+            ((ManagedContext) context).activate();
+        } else if (context instanceof ApplicationContext) {
+            // No-op, always active
+        } else {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    @Override
+    public void setInactive(Context context) {
+        context = ForwardingContext.unwrap(context);
+        if (context instanceof ManagedContext) {
+            ((ManagedContext) context).deactivate();
+        } else {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    @Override
+    public DependentContext getDependentContext() {
+        return Container.instance().deploymentManager().instance().select(DependentContext.class).get();
+    }
+
+    @Override
+    public void destroyContext(Context context) {
+        context = ForwardingContext.unwrap(context);
+        if (context instanceof ManagedContext) {
+            ManagedContext managedContext = (ManagedContext) context;
+            managedContext.invalidate();
+            managedContext.deactivate();
+            managedContext.activate();
+        } else if (context instanceof ApplicationContext) {
+            ((ApplicationContext) context).invalidate();
+        } else {
+            throw new UnsupportedOperationException();
+        }
+    }
+}

--- a/glassfish-tck-runner/src/test/java/org/jboss/weld/tck/glassfish/GlassFishDeploymentExceptionTransformer.java
+++ b/glassfish-tck-runner/src/test/java/org/jboss/weld/tck/glassfish/GlassFishDeploymentExceptionTransformer.java
@@ -13,7 +13,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  */
-// Portions Copyright [2022] [Payara Foundation and/or its affiliates]
+// Portions Copyright [2024] [Payara Foundation and/or its affiliates]
 
 package org.jboss.weld.tck.glassfish;
 
@@ -22,42 +22,55 @@ import java.util.List;
 import jakarta.enterprise.inject.spi.DefinitionException;
 import jakarta.enterprise.inject.spi.DeploymentException;
 
+import org.apache.commons.lang.exception.ExceptionUtils;
 import org.jboss.arquillian.container.spi.client.container.DeploymentExceptionTransformer;
 
 /**
  *
  * See AS7-1197 for more details.
- * 
+ *
  * @see org.jboss.weld.tck.glassfish.GlassFishExtension
  * @author J J Snyder (j.j.snyder@oracle.com)
  */
 public class GlassFishDeploymentExceptionTransformer implements DeploymentExceptionTransformer {
 
     private static final String[] DEPLOYMENT_EXCEPTION_FRAGMENTS = new String[] {
+            "Only normal scopes can be passivating",
             "org.jboss.weld.exceptions.DeploymentException",
             "org.jboss.weld.exceptions.UnserializableDependencyException",
             "org.jboss.weld.exceptions.InconsistentSpecializationException",
             "CDI deployment failure:",
             "org.jboss.weld.exceptions.NullableDependencyException" };
 
-    private static final String[] DEFINITION_EXCEPTION_FRAGMENTS = new String[]
-            { "CDI definition failure:",
-              "org.jboss.weld.exceptions.DefinitionException" };
+    private static final String[] DEFINITION_EXCEPTION_FRAGMENTS = new String[] { "CDI definition failure:",
+            "org.jboss.weld.exceptions.DefinitionException" };
 
+    @Override
     public Throwable transform(Throwable throwable) {
 
         // Arquillian sometimes returns InvocationException with nested AS7
         // exception and sometimes AS7 exception itself
-        Throwable root = throwable;
+        @SuppressWarnings("unchecked")
+        List<Throwable> throwableList = ExceptionUtils.getThrowableList(throwable);
+        if (throwableList.size() < 1)
+            return throwable;
+
+        Throwable root = null;
+
+        if (throwableList.size() == 1) {
+            root = throwable;
+        } else {
+            root = ExceptionUtils.getRootCause(throwable);
+        }
 
         if (root instanceof DeploymentException || root instanceof DefinitionException) {
             return root;
         }
         if (isFragmentFound(DEPLOYMENT_EXCEPTION_FRAGMENTS, root)) {
-            return new DeploymentException(root);
+            return new DeploymentException(root.getMessage());
         }
         if (isFragmentFound(DEFINITION_EXCEPTION_FRAGMENTS, root)) {
-            return new DefinitionException(root);
+            return new DefinitionException(root.getMessage());
         }
         return throwable;
     }

--- a/glassfish-tck-runner/src/test/java/org/jboss/weld/tck/glassfish/GlassFishELImpl.java
+++ b/glassfish-tck-runner/src/test/java/org/jboss/weld/tck/glassfish/GlassFishELImpl.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2013, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package org.jboss.weld.tck.glassfish;
+
+import jakarta.el.ArrayELResolver;
+import jakarta.el.BeanELResolver;
+import jakarta.el.CompositeELResolver;
+import jakarta.el.ELContext;
+import jakarta.el.ELContextEvent;
+import jakarta.el.ELContextListener;
+import jakarta.el.ELResolver;
+import jakarta.el.ExpressionFactory;
+import jakarta.el.FunctionMapper;
+import jakarta.el.ListELResolver;
+import jakarta.el.MapELResolver;
+import jakarta.el.ResourceBundleELResolver;
+import jakarta.el.VariableMapper;
+import jakarta.enterprise.inject.spi.BeanManager;
+
+import org.jboss.cdi.tck.spi.EL;
+import org.jboss.weld.bean.builtin.BeanManagerProxy;
+import org.jboss.weld.manager.BeanManagerImpl;
+import org.jboss.weld.module.web.el.WeldELContextListener;
+import org.jboss.weld.module.web.el.WeldExpressionFactory;
+
+public class GlassFishELImpl implements EL {
+
+    private static final ExpressionFactory EXPRESSION_FACTORY = new WeldExpressionFactory(ExpressionFactory.newInstance());
+
+    private static final ELContextListener[] EL_CONTEXT_LISTENERS = { new WeldELContextListener() };
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T> T evaluateValueExpression(BeanManager beanManager, String expression, Class<T> expectedType) {
+        ELContext elContext = createELContext(beanManager);
+        return (T) EXPRESSION_FACTORY.createValueExpression(elContext, expression, expectedType).getValue(elContext);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T> T evaluateMethodExpression(BeanManager beanManager, String expression, Class<T> expectedType,
+                                          Class<?>[] expectedParamTypes, Object[] expectedParams) {
+        ELContext elContext = createELContext(beanManager);
+        return (T) EXPRESSION_FACTORY.createMethodExpression(elContext, expression, expectedType, expectedParamTypes).invoke(
+                elContext, expectedParams);
+    }
+
+    @Override
+    public ELContext createELContext(BeanManager beanManager) {
+        if (beanManager instanceof BeanManagerProxy) {
+            BeanManagerProxy proxy = (BeanManagerProxy) beanManager;
+            beanManager = proxy.delegate();
+        }
+        if (beanManager instanceof BeanManagerImpl) {
+            return createELContext((BeanManagerImpl) beanManager);
+        }
+        throw new IllegalStateException("Wrong manager");
+    }
+
+    private ELContext createELContext(BeanManagerImpl beanManagerImpl) {
+
+        final ELResolver resolver = createELResolver(beanManagerImpl);
+
+        ELContext context = new ELContext() {
+
+            @Override
+            public ELResolver getELResolver() {
+                return resolver;
+            }
+
+            @Override
+            public FunctionMapper getFunctionMapper() {
+                return null;
+            }
+
+            @Override
+            public VariableMapper getVariableMapper() {
+                return null;
+            }
+
+        };
+        callELContextListeners(context);
+        return context;
+    }
+
+    private ELResolver createELResolver(BeanManagerImpl beanManagerImpl) {
+        CompositeELResolver resolver = new CompositeELResolver();
+        resolver.add(beanManagerImpl.getELResolver());
+        resolver.add(new MapELResolver());
+        resolver.add(new ListELResolver());
+        resolver.add(new ArrayELResolver());
+        resolver.add(new ResourceBundleELResolver());
+        resolver.add(new BeanELResolver());
+        return resolver;
+    }
+
+    private void callELContextListeners(ELContext context) {
+        ELContextEvent event = new ELContextEvent(context);
+        for (ELContextListener listener : EL_CONTEXT_LISTENERS) {
+            listener.contextCreated(event);
+        }
+    }
+}

--- a/glassfish-tck-runner/src/test/java/org/jboss/weld/tck/glassfish/GlassFishExtension.java
+++ b/glassfish-tck-runner/src/test/java/org/jboss/weld/tck/glassfish/GlassFishExtension.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2013, 2018 Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2019, 2020 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -14,12 +14,10 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  */
-
 package org.jboss.weld.tck.glassfish;
 
 import org.jboss.arquillian.container.spi.client.container.DeploymentExceptionTransformer;
 import org.jboss.arquillian.core.spi.LoadableExtension;
-//import org.jboss.as.arquillian.container.ExceptionTransformer;
 
 /**
  * Registers the exception transformer to properly identify deployment failures.
@@ -34,12 +32,6 @@ public class GlassFishExtension implements LoadableExtension {
 
         if (Validate.classExists(PAYARA_CLIENTUTILS_CLASS)) {
             builder.service(DeploymentExceptionTransformer.class, GlassFishDeploymentExceptionTransformer.class);
-//            builder.service(ExceptionTransformer.class, GlassFishDeploymentExceptionTransformer.class);
-            // Override the default NOOP exception transformer
-//            builder.override(DeploymentExceptionTransformer.class,
-//                             ExceptionTransformer.class,
-//                             GlassFishDeploymentExceptionTransformer.class);
-            // Observe container start and check EE resources
             builder.observer(GlassFishResourceManager.class);
         }
     }

--- a/glassfish-tck-runner/src/test/java/org/jboss/weld/tck/glassfish/GlassFishResourceManager.java
+++ b/glassfish-tck-runner/src/test/java/org/jboss/weld/tck/glassfish/GlassFishResourceManager.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2013, 2020 Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2019, 2020 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -20,8 +20,6 @@ package org.jboss.weld.tck.glassfish;
 import org.jboss.arquillian.container.spi.event.StartContainer;
 import org.jboss.arquillian.core.api.annotation.Observes;
 import org.jboss.arquillian.core.spi.EventContext;
-
-import java.util.List;
 
 /**
  * @author <a href="mailto:j.j.snyder@oracle.com">JJ Snyder</a>

--- a/glassfish-tck-runner/src/test/resources/META-INF/cdi-tck.properties
+++ b/glassfish-tck-runner/src/test/resources/META-INF/cdi-tck.properties
@@ -13,9 +13,13 @@
 #
 # SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 #
+# Portions Copyright [2022] [Payara Foundation and/or its affiliates]
 
+org.jboss.cdi.tck.spi.CreationalContexts=org.jboss.weld.tck.glassfish.GlassFishCreationalContextsImpl
+org.jboss.cdi.tck.spi.Contextuals=org.jboss.weld.tck.glassfish.GlassFishContextualsImpl
+org.jboss.cdi.tck.spi.Beans=org.jboss.weld.tck.glassfish.GlassFishBeansImpl
+org.jboss.cdi.tck.spi.Contexts=org.jboss.weld.tck.glassfish.GlassFishContextImpl
+org.jboss.cdi.tck.spi.EL=org.jboss.weld.tck.glassfish.GlassFishELImpl
 org.jboss.cdi.tck.testJmsConnectionFactory=java:comp/DefaultJMSConnectionFactory
 org.jboss.cdi.tck.testJmsQueue=queue_test
 org.jboss.cdi.tck.testJmsTopic=topic_test
-org.jboss.cdi.tck.spi.CreationalContexts=org.jboss.weld.tck.glassfish.GlassFishCreationalContextsImpl
-org.jboss.cdi.tck.spi.Contextuals=org.jboss.weld.tck.glassfish.GlassFishContextualsImpl

--- a/glassfish-tck-runner/src/test/resources/META-INF/cdi-tck.properties
+++ b/glassfish-tck-runner/src/test/resources/META-INF/cdi-tck.properties
@@ -13,7 +13,7 @@
 #
 # SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 #
-# Portions Copyright [2022] [Payara Foundation and/or its affiliates]
+# Portions Copyright [2022-2024] [Payara Foundation and/or its affiliates]
 
 org.jboss.cdi.tck.spi.CreationalContexts=org.jboss.weld.tck.glassfish.GlassFishCreationalContextsImpl
 org.jboss.cdi.tck.spi.Contextuals=org.jboss.weld.tck.glassfish.GlassFishContextualsImpl

--- a/glassfish-tck-runner/src/test/tck20/tck-tests.xml
+++ b/glassfish-tck-runner/src/test/tck20/tck-tests.xml
@@ -18,25 +18,19 @@
     <test name="CDI TCK">
 
         <packages>
+
+            <!--package name="org.jboss.cdi.tck.tests.context.*" /-->
             <package name="org.jboss.cdi.tck.tests.*" />
             <package name="org.jboss.cdi.tck.interceptors.tests.*" />
         </packages>
 
         <classes>
-            <!-- CDITCK-587 -->
-            <class name="org.jboss.cdi.tck.tests.event.observer.transactional.roolback.TransactionalObserverRollbackTest">
+            <!-- https://github.com/jakartaee/cdi-tck/issues/440 -->
+            <class name="org.jboss.cdi.tck.tests.full.extensions.lifecycle.processBeanAttributes.specialization.VetoTest">
                 <methods>
                     <exclude name=".*"/>
                 </methods>
             </class>
-
-            <!-- CDITCK-597 -->
-            <class name="org.jboss.cdi.tck.tests.deployment.packaging.ejb.EJBJarDeploymentTest">
-                <methods>
-                    <exclude name=".*"/>
-                </methods>
-            </class>
-
         </classes>
     </test>
 


### PR DESCRIPTION
This PR is to improve and fix the CDI TCK 4.1 execution and the following is the list of improvements added for this project:

1. We don't need with the latest changes the project: glassfish-cdi-porting-tck
2. The classes used on the glassfish-cdi-porting-tck now were added to the src folder of the glassfish-tck-runner
3. Upgrade of the pom template to build a local jar with the latest changes to be loaded as providers during execution of tests 
Result of TCK execution:
![image](https://github.com/user-attachments/assets/52ab8973-277d-456c-8da8-4e5f8da1135e)

To build correctly the TCK it is needed to merge the following PR from Payara Server 7 branch: https://github.com/payara/Payara/pull/6849