### PR TITLE
FISH-10295: upgrading tck version and weld to fix tck issues

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -51,5 +51,5 @@ max.perm.gen.size=1024m
 # found under ${porting.home}/glassfish-tck-runner/target/surefire-reports
 ######################################################
 report.dir=${porting.home}/reports
-cdiextjar=cdi-tck-ext-lib-4.0.7.jar
-cdiext.version=4.0.7
+cdiextjar=cdi-tck-ext-lib-4.0.13.jar
+cdiext.version=4.0.13

--- a/glassfish-tck-runner/pom.template.xml
+++ b/glassfish-tck-runner/pom.template.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>weld-core-parent</artifactId>
         <groupId>org.jboss.weld</groupId>
-        <version>5.0.1.Final</version>
+        <version>5.1.2.Final</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
@@ -42,7 +42,7 @@
         <shrinkwrap.version>1.2.6</shrinkwrap.version>
         <minimum.maven.version>3.0.5</minimum.maven.version>
         <cdi.api.version>4.0.1</cdi.api.version>
-        <cdi.tck.version>4.0.7</cdi.tck.version>
+        <cdi.tck.version>4.0.13</cdi.tck.version>
         <httpcomponents.version>4.5.5</httpcomponents.version>
         <arquillian.version>1.7.0.Alpha10</arquillian.version>
         <jakarta.platform.version>10.0.0</jakarta.platform.version>

--- a/glassfish-tck-runner/pom.template.xml
+++ b/glassfish-tck-runner/pom.template.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>weld-core-parent</artifactId>
         <groupId>org.jboss.weld</groupId>
-        <version>5.0.1.payara-p1-SNAPSHOT</version>
+        <version>5.0.1.payara-p1</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/glassfish-tck-runner/pom.template.xml
+++ b/glassfish-tck-runner/pom.template.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>weld-core-parent</artifactId>
         <groupId>org.jboss.weld</groupId>
-        <version>5.1.2.Final</version>
+        <version>5.0.1.payara-p1-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>


### PR DESCRIPTION
With the following upgrade of versions now the cdi tck is passing with success:

![image](https://github.com/user-attachments/assets/c2ea467d-a6dc-4d2c-a69e-2017686dc216)
